### PR TITLE
Prometheus demo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,12 +31,17 @@ inThisBuild(
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
-val zioVersion = "1.0.0-RC18-2"
+val zioVersion        = "1.0.0-RC18-2"
+val prometheusVersion = "0.8.1"
+
 libraryDependencies ++= Seq(
-  "dev.zio" %% "zio"          % zioVersion,
-  "dev.zio" %% "zio-nio"      % "1.0.0-RC6",
-  "dev.zio" %% "zio-test"     % zioVersion % "test",
-  "dev.zio" %% "zio-test-sbt" % zioVersion % "test"
+  "dev.zio"       %% "zio"                    % zioVersion,
+  "dev.zio"       %% "zio-nio"                % "1.0.0-RC6",
+  "dev.zio"       %% "zio-test"               % zioVersion % "test",
+  "dev.zio"       %% "zio-test-sbt"           % zioVersion % "test",
+  "io.prometheus" % "simpleclient"            % prometheusVersion % "test",
+  "io.prometheus" % "simpleclient_common"     % prometheusVersion % "test",
+  "io.prometheus" % "simpleclient_httpserver" % prometheusVersion % "test"
 )
 
 testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))

--- a/src/main/scala/zio/package.scala
+++ b/src/main/scala/zio/package.scala
@@ -121,7 +121,7 @@ package object zmx extends MetricsDataModel with MetricsConfigDataModel {
       def listen(): ZIO[Clock, Throwable, Fiber.Runtime[Throwable, Nothing]]
 
       def listen(
-        f: List[Metric[_]] => Task[List[Long]]
+        f: List[Metric[_]] => IO[Exception, List[Long]]
       ): ZIO[Clock, Throwable, Fiber.Runtime[Throwable, Nothing]]
     }
 
@@ -288,7 +288,7 @@ package object zmx extends MetricsDataModel with MetricsConfigDataModel {
 
       def listen(): ZIO[Clock, Throwable, Fiber.Runtime[Throwable, Nothing]] = listen(udp)
       def listen(
-        f: List[Metric[_]] => Task[List[Long]]
+        f: List[Metric[_]] => IO[Exception, List[Long]]
       ): ZIO[Clock, Throwable, Fiber.Runtime[Throwable, Nothing]] = {
         println(s"Listen: ${ring.size()}")
         collect(f).forever.forkDaemon <& sendIfNotEmpty(f).repeat(everyNSec).forkDaemon
@@ -408,7 +408,7 @@ package object zmx extends MetricsDataModel with MetricsConfigDataModel {
         override def listen(): ZIO[Clock, Throwable, Fiber.Runtime[Throwable, Nothing]] = unsafe.listen()
 
         override def listen(
-          f: List[Metric[_]] => Task[List[Long]]
+          f: List[Metric[_]] => IO[Exception, List[Long]]
         ): ZIO[Clock, Throwable, Fiber.Runtime[Throwable, Nothing]] = unsafe.listen(f)
       }
     }
@@ -487,7 +487,7 @@ package object zmx extends MetricsDataModel with MetricsConfigDataModel {
       ZIO.accessM[Metrics](_.get.listen().provideSomeLayer(Clock.live))
 
     def listen(
-      f: List[Metric[_]] => Task[List[Long]]
+      f: List[Metric[_]] => IO[Exception, List[Long]]
     ): ZIO[Clock with Metrics, Throwable, Fiber.Runtime[Throwable, Nothing]] =
       ZIO.accessM[Metrics](_.get.listen(f).provideSomeLayer(Clock.live))
 

--- a/src/test/scala/zio/PrometheusSpec.scala
+++ b/src/test/scala/zio/PrometheusSpec.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import zio.zmx.Metrics._
+import zio.duration._
+import zio.zmx._
+import zio.clock.Clock
+import zio.console._
+
+import io.prometheus.client.CollectorRegistry
+import io.prometheus.client.{ Counter => PCounter, Histogram => PHistogram }
+import io.prometheus.client.exporter.common.TextFormat
+import io.prometheus.client.exporter.HTTPServer
+
+import java.io.StringWriter
+import java.io.InvalidObjectException
+import java.net.InetSocketAddress
+
+object PrometheusSpec {
+
+  val config = new MetricsConfig(20, 5, 5.seconds, None, None)
+
+  val someExternalRegistry = CollectorRegistry.defaultRegistry
+  val c = PCounter
+    .build()
+    .name("PrometheusCounter")
+    .labelNames(Array("class", "method"): _*)
+    .help(s"Sample prometheus counter")
+    .register(someExternalRegistry)
+
+  val h = PHistogram
+    .build()
+    .name("PrometheusHistogram")
+    .labelNames(Array("class", "method"): _*)
+    .help(s"Sample prometheus histogram")
+    .register(someExternalRegistry)
+
+  def write004(r: CollectorRegistry): Task[String] =
+    Task {
+      val writer = new StringWriter
+      TextFormat.write004(writer, r.metricFamilySamples)
+      writer.toString
+    }
+
+  def http(r: CollectorRegistry, port: Int): zio.Task[HTTPServer] =
+    Task {
+      new HTTPServer(new InetSocketAddress(port), r)
+    }
+
+  val matchMetric: Metric[_] => IO[Exception, Long] = m => {
+    val e = new InvalidObjectException("Unknown Metric! Should not happen")
+    val lngs = m match {
+      case Metric.Counter(n, v, _, ts) =>
+        IO {
+          val tags = n +: (ts.map(_.value).toArray)
+          c.labels(tags: _*).inc(v)
+          v.toLong
+        }
+      case Metric.Histogram(n, v, _, ts) =>
+        IO {
+          val tags = n +: (ts.map(_.value).toArray)
+          h.labels(tags: _*).observe(v)
+          v.toLong
+        }
+      case _ => IO.fail(e)
+    }
+    lngs.orElseFail(e)
+  }
+
+  val instrument: List[Metric[_]] => IO[Exception, List[Long]] =
+    metrics => {
+      for {
+        longs <- IO.foreach(metrics)(matchMetric)
+      } yield { println(s"Sent: $longs"); longs }
+    }
+
+  val sendOnTimeout: RIO[Metrics with Clock, String] = for {
+    _    <- counter("test-zmx", 1.0, 1.0, Tag("test", "zmx"))
+    _    <- counter("test-zmx", 3.0, 1.0, Tag("test", "zmx"))
+    _    <- counter("test-zmx", 5.0, 1.0, Tag("test", "zmx"))
+    _    <- counter("test-zmx", 2.0, 1.0, Tag("test", "zmx"))
+    _    <- counter("test-zmx", 3.0, 1.0, Tag("test", "zmx"))
+    _    <- counter("test-zmx", 4.0, 1.0, Tag("test", "zmx"))
+    _    <- histogram("test-zmx", 3.0, 1.0, Tag("test", "zmx"))
+    _    <- histogram("test-zmx", 4.0, 1.0, Tag("test", "zmx"))
+    _    <- listen(instrument)
+    r004 <- write004(someExternalRegistry)
+  } yield r004
+
+  val rt = Runtime.unsafeFromLayer(Metrics.live(config) ++ Clock.live ++ Console.live)
+
+  val program = for {
+    s      <- sendOnTimeout
+    _      <- putStrLn(s)
+    server <- http(someExternalRegistry, config.port.getOrElse(9090))
+  } yield server
+
+  def main(args: Array[String]): Unit = {
+    val server = rt.unsafeRun(program)
+    Thread.sleep(60000)
+    println("TIME!")
+    server.stop()
+  }
+}


### PR DESCRIPTION
`test/zio.PrometheusSpec.scala` starts a Prometheus Server, the trick here is that it uses the version of `listen` where we pass our own function. In this case, the function is just a mapping from a our `Metric` objects to a Prometheus one.