### PR TITLE
Add RESP implementation with tests

### DIFF
--- a/src/main/scala/zio/zmx/diagnostics/parser/Resp.scala
+++ b/src/main/scala/zio/zmx/diagnostics/parser/Resp.scala
@@ -1,0 +1,275 @@
+package zio.zmx.diagnostics.parser
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+import zio.{ Chunk, IO }
+
+import scala.annotation.tailrec
+
+/**
+ * Implementation of RESP (REdis Serialization Protocol)
+ *
+ * Protocol specification: https://redis.io/topics/protocol
+ *
+ * Following simplifications were made in this implementation:
+ *
+ *  - Strings in __Simple Strings__ and __Errors__ have `\r` and `\n` removed automatically
+ *      upon creation, see: [[Resp.normalized]] method for details,
+ *
+ *  - When serializing strings, they are encoded using UTF-8 in [[Resp.encode]] method,
+ *
+ *  - While the __Bulk Strings__ could be used to store and transfer arbitrary binary data
+ *      for simplification of the API we limit them to just correct UTF-8 bytes
+ *      that are decoded to [[String]] type.
+ */
+private[zmx] object Resp {
+
+  /**
+   * RESP protocol internals
+   */
+
+  /** Headers of RESP data types */
+  private final val SimpleStringHeader: Byte = '+'
+  private final val ErrorHeader: Byte        = '-'
+  private final val IntegerHeader: Byte      = ':'
+  private final val BulkStringHeader: Byte   = '$'
+  private final val ArrayHeader: Byte        = '*'
+
+  /** Different parts of the protocol are always terminated with `CRLF` */
+  private final val CarriageReturn: Byte    = '\r'
+  private final val LineFeed: Byte          = '\n'
+  private final val Terminator: Chunk[Byte] = Chunk(CarriageReturn, LineFeed)
+
+  /**
+   * In accordance with the RESP specification, __Simple Strings__ and __Errors__ both
+   * represent strings that cannot contain a CR or LF characters (no newlines are allowed).
+   * To simplify the API and avoid need for refined types and refining code we just
+   * remove all forbidden characters from input upon creation.
+   */
+  private def normalized(value: String): String =
+    value.filterNot(Terminator.contains(_))
+
+  /** Strings are encoded using UTF-8 */
+  private def encode(value: String): Chunk[Byte] =
+    Chunk.fromArray(value.getBytes(UTF_8))
+
+  /** Integers are represented as decimals */
+  private def encode(value: Long): Chunk[Byte] =
+    encode(value.toString)
+
+  /**
+   * Bytes are expected to be UTF-8 encoded
+   *
+   * Default JVM UTF-8 decoder cannot fail because it replaces malformed-input and unmappable-character
+   * sequences automatically with the Unicode replacement character.
+   *
+   * For detection of malformed UTF-8 bytes sequences custom `CharsetDecoder` with `CodingErrorAction.REPORT`
+   * action for malformed-input and unmappable-character sequences could be used, then wrapped with `Try`/`IO`
+   * to handle that properly. For simplification we assume only correct strings should be sent.
+   */
+  private def decode(bytes: Chunk[Byte]): String =
+    new String(bytes.toArray, UTF_8)
+
+  /**
+   * RESP data types and serialization
+   */
+
+  /** General type that all RESP data types extend */
+  sealed trait RespValue {
+    def serialize: Chunk[Byte]
+  }
+
+  /** RESP Simple Strings */
+  sealed abstract case class SimpleString private (value: String) extends RespValue {
+    override def serialize: Chunk[Byte] =
+      SimpleStringHeader +: encode(value) ++: Terminator
+  }
+  object SimpleString {
+    def apply(value: String): SimpleString =
+      new SimpleString(normalized(value)) {}
+  }
+
+  /** RESP Errors */
+  sealed abstract case class Error private (value: String) extends RespValue {
+    override def serialize: Chunk[Byte] =
+      ErrorHeader +: encode(value) ++: Terminator
+  }
+  object Error {
+    def apply(value: String): Error =
+      new Error(normalized(value)) {}
+  }
+
+  /** RESP Integers */
+  final case class Integer(value: Long) extends RespValue {
+    override def serialize: Chunk[Byte] =
+      IntegerHeader +: encode(value) ++: Terminator
+  }
+
+  /** RESP Bulk Strings */
+  final case class BulkString(value: String) extends RespValue {
+    override def serialize: Chunk[Byte] = {
+      val encodedData = encode(value)
+      val encodedSize = encodedData.size.toLong
+
+      BulkStringHeader +:                      // Header byte
+        encode(encodedSize) ++: Terminator ++: // Size of the data
+        encodedData ++: Terminator             // Data and the terminator
+    }
+  }
+
+  /** RESP Arrays */
+  final case class Array(items: Chunk[RespValue]) extends RespValue {
+    override def serialize: Chunk[Byte] =
+      ArrayHeader +:                                      // Header byte
+        encode(items.size.toLong) ++: Terminator ++:      // Items count
+        items.map(_.serialize).fold(Chunk.empty)(_ ++: _) // Each item serialized
+  }
+  object Array {
+    def apply(items: RespValue*): Array =
+      Array(Chunk(items: _*))
+  }
+
+  /** RESP Null */
+  final case object NoValue extends RespValue {
+    override def serialize: Chunk[Byte] = {
+      val NullCount: Chunk[Byte] = Chunk('-', '1')
+
+      /**
+       * Null value representation
+       *
+       * There is more than one way to serialize a __Null__ value in RESP.
+       * Usually the __Null Bulk String__ is used:
+       */
+      BulkStringHeader +: NullCount ++: Terminator
+
+      /**
+       * But for historical reasons there is also __Null Array__ representation:
+       * {{{
+       *   ArrayHeader +: NullCount ++: Terminator
+       * }}}
+       */
+    }
+
+  }
+
+  /**
+   * RESP parser
+   */
+
+  /** Parsing error */
+  sealed trait ParsingError
+
+  final case class ExcessiveData(remainder: Chunk[Byte]) extends ParsingError
+  final case class InvalidInteger(text: String)          extends ParsingError
+  final case class InvalidSize(size: Int)                extends ParsingError
+  final case class UnknownHeader(byte: Byte)             extends ParsingError
+  final case object MalformedData                        extends ParsingError
+  final case object UnexpectedEndOfData                  extends ParsingError
+
+  /** RESP parser */
+  def parse(data: Chunk[Byte]): IO[ParsingError, RespValue] = {
+
+    /** Intermediate values */
+    final case class BasicString(string: String, remainder: Chunk[Byte])
+    final case class BasicInt(int: Int, remainder: Chunk[Byte])
+    final case class BasicLong(long: Long, remainder: Chunk[Byte])
+
+    /**
+     * Helper functions for taking sequence of bytes terminated with a `CRLF`
+     *
+     * These produce [[BasicString]], [[BasicInt]] and [[BasicLong]] values respectively.
+     */
+
+    @tailrec def takeString(data: Chunk[Byte], result: Chunk[Byte] = Chunk.empty): IO[ParsingError, BasicString] =
+      data match {
+        case CarriageReturn +: LineFeed +: tail => IO.succeed(BasicString(decode(result), tail))
+        case byte +: tail                       => takeString(tail, result :+ byte)
+        case _                                  => IO.fail(UnexpectedEndOfData)
+      }
+
+    def takeInt(data: Chunk[Byte]): IO[ParsingError, BasicInt] =
+      for {
+        part <- takeString(data)
+        int  <- IO.effect(part.string.toInt).orElseFail(InvalidInteger(part.string))
+      } yield BasicInt(int, part.remainder)
+
+    def takeLong(data: Chunk[Byte]): IO[ParsingError, BasicLong] =
+      for {
+        part <- takeString(data)
+        long <- IO.effect(part.string.toLong).orElseFail(InvalidInteger(part.string))
+      } yield BasicLong(long, part.remainder)
+
+    /** Partial result of parsing */
+    final case class ParsedFragment(result: RespValue, remainder: Chunk[Byte])
+
+    /** Parsing process */
+    def process(data: Chunk[Byte]): IO[ParsingError, ParsedFragment] = data match {
+
+      case SimpleStringHeader +: tail =>
+        for {
+          part <- takeString(tail)
+        } yield ParsedFragment(SimpleString(part.string), part.remainder)
+
+      case ErrorHeader +: tail =>
+        for {
+          part <- takeString(tail)
+        } yield ParsedFragment(Error(part.string), part.remainder)
+
+      case IntegerHeader +: tail =>
+        for {
+          part <- takeLong(tail)
+        } yield ParsedFragment(Integer(part.long), part.remainder)
+
+      case BulkStringHeader +: tail =>
+        def bulk(size: Int, data: Chunk[Byte]): IO[ParsingError, ParsedFragment] = {
+          val (result, tail)          = data.splitAt(size)
+          val (terminator, remainder) = tail.splitAt(Terminator.size)
+
+          for {
+            _ <- IO.fail(UnexpectedEndOfData).when(result.size != size || terminator.size != Terminator.size)
+            _ <- IO.fail(MalformedData).when(terminator != Terminator)
+          } yield ParsedFragment(BulkString(decode(result)), remainder)
+        }
+
+        takeInt(tail).flatMap {
+          case BasicInt(-1, remainder)                => IO.succeed(ParsedFragment(NoValue, remainder))
+          case BasicInt(size, remainder) if size >= 0 => bulk(size, remainder)
+          case BasicInt(other, _)                     => IO.fail(InvalidSize(other))
+        }
+
+      case ArrayHeader +: tail =>
+        def array(
+          count: Int,
+          data: Chunk[Byte],
+          result: Chunk[RespValue] = Chunk.empty
+        ): IO[ParsingError, ParsedFragment] =
+          if (count < 1) {
+            IO.succeed(ParsedFragment(Array(result), data))
+          } else {
+            process(data).flatMap { case ParsedFragment(item, remainder) =>
+              array(count - 1, remainder, result :+ item)
+            }
+          }
+
+        takeInt(tail).flatMap {
+          case BasicInt(-1, remainder)                => IO.succeed(ParsedFragment(NoValue, remainder))
+          case BasicInt(size, remainder) if size >= 0 => array(size, remainder)
+          case BasicInt(other, _)                     => IO.fail(InvalidSize(other))
+        }
+
+      case header +: _ =>
+        IO.fail(UnknownHeader(header))
+
+      case _ =>
+        IO.fail(UnexpectedEndOfData)
+
+    }
+
+    process(data).flatMap {
+      case ParsedFragment(result, Chunk.empty) => IO.succeed(result)
+      case ParsedFragment(_, remainder)        => IO.fail(ExcessiveData(remainder))
+    }
+
+  }
+
+}

--- a/src/main/scala/zio/zmx/diagnostics/parser/Resp.scala
+++ b/src/main/scala/zio/zmx/diagnostics/parser/Resp.scala
@@ -133,16 +133,14 @@ private[zmx] object Resp {
   final case object NoValue extends RespValue {
     override def serialize: Chunk[Byte] = {
       val NullCount: Chunk[Byte] = Chunk('-', '1')
-
-      /**
+      /*
        * Null value representation
        *
        * There is more than one way to serialize a __Null__ value in RESP.
        * Usually the __Null Bulk String__ is used:
        */
       BulkStringHeader +: NullCount ++: Terminator
-
-      /**
+      /*
        * But for historical reasons there is also __Null Array__ representation:
        * {{{
        *   ArrayHeader +: NullCount ++: Terminator
@@ -169,12 +167,15 @@ private[zmx] object Resp {
   /** RESP parser */
   def parse(data: Chunk[Byte]): IO[ParsingError, RespValue] = {
 
-    /** Intermediate values */
+    /*
+     * Intermediate values
+     */
+
     final case class BasicString(string: String, remainder: Chunk[Byte])
     final case class BasicInt(int: Int, remainder: Chunk[Byte])
     final case class BasicLong(long: Long, remainder: Chunk[Byte])
 
-    /**
+    /*
      * Helper functions for taking sequence of bytes terminated with a `CRLF`
      *
      * These produce [[BasicString]], [[BasicInt]] and [[BasicLong]] values respectively.
@@ -199,10 +200,10 @@ private[zmx] object Resp {
         long <- IO.effect(part.string.toLong).orElseFail(InvalidInteger(part.string))
       } yield BasicLong(long, part.remainder)
 
-    /** Partial result of parsing */
+    /* Partial result of parsing */
     final case class ParsedFragment(result: RespValue, remainder: Chunk[Byte])
 
-    /** Parsing process */
+    /* Parsing process */
     def process(data: Chunk[Byte]): IO[ParsingError, ParsedFragment] = data match {
 
       case SimpleStringHeader +: tail =>

--- a/src/test/scala/zio/zmx/diagnostics/parser/RespSpec.scala
+++ b/src/test/scala/zio/zmx/diagnostics/parser/RespSpec.scala
@@ -1,0 +1,27 @@
+package zio.zmx.diagnostics.parser
+
+import zio.test.Assertion._
+import zio.test._
+
+object RespSpec extends DefaultRunnableSpec {
+  override def spec =
+    suite("RespSpec")(RespTestCases.scenarios.map {
+
+      case RespTestCases.Success(description, input, expectedResult, expectedReserialization) =>
+        testM(s"Resp implementation parses and serializes **$description** correctly") {
+          for {
+            parsingResult      <- Resp.parse(input)
+            serializationResult = expectedResult.serialize
+          } yield assert(parsingResult)(equalTo(expectedResult)) &&
+            assert(serializationResult)(equalTo(expectedReserialization))
+        }
+
+      case RespTestCases.Failure(description, input, expectedParsingError) =>
+        testM(s"Resp implementation fails on **$description** correctly") {
+          for {
+            parsingError <- Resp.parse(input).flip
+          } yield assert(parsingError)(equalTo(expectedParsingError))
+        }
+
+    }: _*)
+}

--- a/src/test/scala/zio/zmx/diagnostics/parser/RespTestCases.scala
+++ b/src/test/scala/zio/zmx/diagnostics/parser/RespTestCases.scala
@@ -1,0 +1,343 @@
+package zio.zmx.diagnostics.parser
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+import zio.Chunk
+import zio.zmx.diagnostics.parser.Resp._
+
+object RespTestCases {
+
+  /** Helper for creating `Chunk[Byte]` from `String` */
+  private def resp(value: String): Chunk[Byte] =
+    Chunk.fromArray(value.getBytes(UTF_8))
+
+  /** Models for scenarios */
+  sealed trait TestCase
+
+  final case class Success(
+    description: String,
+    input: Chunk[Byte],
+    expectedResult: RespValue,
+    expectedReserialization: Chunk[Byte]
+  ) extends TestCase
+
+  object Success {
+    def apply(description: String, input: Chunk[Byte], expectedResult: RespValue): Success =
+      Success(description, input, expectedResult, expectedReserialization = input)
+  }
+
+  final case class Failure(
+    description: String,
+    input: Chunk[Byte],
+    expectedParsingError: ParsingError
+  ) extends TestCase
+
+  /** Scenarios */
+  final val scenarios = List[TestCase](
+    /** General broken inputs */
+    Failure(
+      "empty input",
+      resp(""),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "unknown header type",
+      resp("?"),
+      UnknownHeader('?')
+    ),
+    Failure(
+      "cut input",
+      resp("+"),
+      UnexpectedEndOfData
+    ),
+    /** RESP Simple Strings */
+    Success(
+      "basic Simple String",
+      resp("+OK\r\n"),
+      SimpleString("OK")
+    ),
+    Success(
+      "empty Simple String",
+      resp("+\r\n"),
+      SimpleString("")
+    ),
+    Failure(
+      "unterminated Simple String",
+      resp("+Test"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "broken (missing LF) Simple String",
+      resp("+Test\r"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "broken (missing CR) Simple String",
+      resp("+Test\n"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "broken (LF CR instead of CR LF) Simple String",
+      resp("+Test\n\r"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "excessive data after Simple String",
+      resp("+Test\r\nABC"),
+      ExcessiveData(Chunk(65, 66, 67))
+    ),
+    Success(
+      "non-ASCII Simple String",
+      resp("+Żółć!\r\n"),
+      SimpleString("Żółć!")
+    ),
+    /** RESP Errors */
+    Success(
+      "basic Error",
+      resp("-Error message\r\n"),
+      Error("Error message")
+    ),
+    Success(
+      "empty Error",
+      resp("-\r\n"),
+      Error("")
+    ),
+    Failure(
+      "unterminated Error",
+      resp("-Test"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "broken (missing LF) Error",
+      resp("-Test\r"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "broken (missing CR) Error",
+      resp("-Test\n"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "broken (LF CR instead of CR LF) Error",
+      resp("-Test\n\r"),
+      UnexpectedEndOfData
+    ),
+    Success(
+      "non-ASCII Error",
+      resp("-Żółć!\r\n"),
+      Error("Żółć!")
+    ),
+    /** RESP Integers */
+    Success(
+      "zero as Integer",
+      resp(":0\r\n"),
+      Integer(0)
+    ),
+    Success(
+      "negative zero as Integer",
+      resp(":-0\r\n"),
+      Integer(0),
+      resp(":0\r\n")
+    ),
+    Success(
+      "positive number as Integer",
+      resp(":1000\r\n"),
+      Integer(1000)
+    ),
+    Success(
+      "negative number as Integer",
+      resp(":-1337\r\n"),
+      Integer(-1337)
+    ),
+    Success(
+      "big positive number as Integer",
+      resp(s":${Long.MaxValue}\r\n"),
+      Integer(Long.MaxValue)
+    ),
+    Success(
+      "big negative number as Integer",
+      resp(s":${Long.MinValue}\r\n"),
+      Integer(Long.MinValue)
+    ),
+    Success(
+      "zero-padded number with plus sign as Integer",
+      resp(":+00017\r\n"),
+      Integer(17),
+      resp(":17\r\n")
+    ),
+    Failure(
+      "non-decimal as Integer",
+      resp(":0xFF\r\n"),
+      InvalidInteger("0xFF")
+    ),
+    Failure(
+      "non-number non-ASCII text as Integer",
+      resp(":Żółć\r\n"),
+      InvalidInteger("Żółć")
+    ),
+    Failure(
+      "unterminated Integer",
+      resp(":0"),
+      UnexpectedEndOfData
+    ),
+    /** RESP Bulk Strings */
+    Success(
+      "basic Bulk String",
+      resp("$6\r\nfoobar\r\n"),
+      BulkString("foobar")
+    ),
+    Success(
+      "empty Bulk String",
+      resp("$0\r\n\r\n"),
+      BulkString("")
+    ),
+    Success(
+      "Null Bulk String",
+      resp("$-1\r\n"),
+      NoValue
+    ),
+    Success(
+      "Bulk String with new lines",
+      resp("$31\r\nalpha beta\rgamma\ndelta\r\nepsilon\r\n"),
+      BulkString("alpha beta\rgamma\ndelta\r\nepsilon")
+    ),
+    Success(
+      "non-ASCII Bulk String",
+      /* Encoded with UTF-8 this Bulk String has length of 15 bytes.
+       *
+       * {{{
+       *   >>> x = "Żółć it is!".encode('utf-8')
+       *   >>> x
+       *   b'\xc5\xbb\xc3\xb3\xc5\x82\xc4\x87 it is!'
+       *   >>> len(x)
+       *   15
+       * }}}
+       */
+      resp("$15\r\nŻółć it is!\r\n"),
+      BulkString("Żółć it is!")
+    ),
+    Failure(
+      "negative length Bulk String",
+      resp("$-3\r\nfoo\r\n"),
+      InvalidSize(-3)
+    ),
+    Failure(
+      "too small length Bulk String",
+      resp("$2\r\nfoo\r\n"),
+      MalformedData
+    ),
+    Failure(
+      "too big length Bulk String",
+      resp("$9\r\nfoo\r\n"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "cut size Bulk String",
+      resp("$9"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "cut data Bulk String",
+      resp("$3\r\nfoo"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "non-number length Bulk String",
+      resp("$bar\r\nfoo\r\n"),
+      InvalidInteger("bar")
+    ),
+    Failure(
+      "out of range length Bulk String",
+      resp("$9999999999999999999999999\r\nfoo\r\n"),
+      InvalidInteger("9999999999999999999999999")
+    ),
+    /** RESP Arrays */
+    Success(
+      "empty Array",
+      resp("*0\r\n"),
+      Array(Chunk.empty)
+    ),
+    Success(
+      "Array with two Bulk Strings",
+      resp("*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"),
+      Array(Chunk(BulkString("foo"), BulkString("bar")))
+    ),
+    Success(
+      "Array with three Integers",
+      resp("*3\r\n:1\r\n:2\r\n:3\r\n"),
+      Array(Integer(1), Integer(2), Integer(3))
+    ),
+    Success(
+      "Array with mixed types",
+      resp("*5\r\n:1\r\n:2\r\n:3\r\n:4\r\n$6\r\nfoobar\r\n"),
+      Array(Integer(1), Integer(2), Integer(3), Integer(4), BulkString("foobar"))
+    ),
+    Success(
+      "Null Array",
+      resp("*-1\r\n"),
+      NoValue,
+      resp("$-1\r\n") // `NoValue` is serialized as Null Bulk String by default
+    ),
+    Success(
+      "Array with nested Array",
+      resp("*2\r\n*3\r\n:1\r\n:2\r\n:3\r\n*2\r\n+Foo\r\n-Bar\r\n"),
+      Array(Array(Integer(1), Integer(2), Integer(3)), Array(SimpleString("Foo"), Error("Bar")))
+    ),
+    Success(
+      "Array with Null values",
+      resp("*3\r\n$3\r\nfoo\r\n$-1\r\n$3\r\nbar\r\n"),
+      Array(BulkString("foo"), NoValue, BulkString("bar"))
+    ),
+    Success(
+      "Array with example Redis command",
+      resp("*2\r\n$4\r\nLLEN\r\n$6\r\nmylist\r\n"),
+      Array(BulkString("LLEN"), BulkString("mylist"))
+    ),
+    Failure(
+      "malformed Bulk String in Array",
+      resp("*1\r\n$3\r\ndump\r\n"),
+      MalformedData
+    ),
+    Failure(
+      "negative Array size",
+      resp("*-5\r\n..."),
+      InvalidSize(-5)
+    ),
+    Failure(
+      "too big Array size",
+      resp("*5\r\n"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "too small Array size",
+      resp("*2\r\n:1\r\n:2\r\n:3\r\n"),
+      ExcessiveData(Chunk(58, 51, 13, 10))
+    ),
+    Failure(
+      "cut data in Array",
+      resp("*3\r\n:1\r\n:2\r\n:3\r"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "cut Array size",
+      resp("*5"),
+      UnexpectedEndOfData
+    ),
+    Failure(
+      "non-number Array size",
+      resp("*foo\r\n:1\r\n:2\r\n:3\r\n"),
+      InvalidInteger("foo")
+    ),
+    Failure(
+      "out of range Array size",
+      resp("*9999999999999999999999999\r\n:1\r\n:2\r\n:3\r\n"),
+      InvalidInteger("9999999999999999999999999")
+    ),
+    Failure(
+      "broken item in Array",
+      resp("*3\r\n:1\r\n:broken\r\n:3\r\n"),
+      InvalidInteger("broken")
+    )
+  )
+
+}


### PR DESCRIPTION
Hello there 👋 

This would be first part of my work around issues #76 and #9.

I've looked into #76 some time ago and concluded that this issue (crashes of the whole server for that and many other incorrect RESP payloads) are caused by unsafe/incomplete RESP parser bundled along the `ZMXParser` causing the unchecked exceptions that resulted in server failures.

I've decided to write complete and fail-safe RESP parser/serializer implementation. I haven't touched `ZMXParser` yet because I've decided to split the work into two PRs to keep them smaller and easier for review. In this PR I'm adding the implementation with extensive tests.
