### PR TITLE
General Cleanup #131: main project ascii-style diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,32 +41,31 @@ Come chat with us on [![Badge-Discord]][Link-Discord].
 
 ## Overview                                                                                                                                                        
                                                                                                                                                         
-                                                                                                                                                        
-            ┌─────────────────────┐                               client -> server                            ┌─────────────────────┐                   
-            │                     ◀━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫                     │                   
-            │     ZMX Server      │                                                                           │     ZMX Client      │                   
-            │                     ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━▶                     │                   
-            └─────────────────────┘                               server -> client                            └─────────────────────┘                   
-                                                                                                                         ┃                              
-                      ┃                        (ZmxProtocol which is based on the Redis RESP protocol)                                                  
-                                                                                                                         ┃                              
-                      ┃                                                                                                                                 
-                                                                                                                         ┃                              
-                      ┃                                                                                                                                 
-                                                                                                                         ▼                              
-                      ▼                                                                                                                                 
-         ┌─────────────────────────────────────────────────────┐                                 ┌─────────────────────────────────────────────────────┐
-         │- Send Command to server                             │                                 │- Send Command to server                             │
-         │- User specified port server is to run on            │                                 │- User specified port server is running on           │
-         │- Always run on localhost where ZIO is running       │                                 │- Client implementations planned:                    │
-         │- Supported Commands Planned:                        │                                 │    - CLI                                            │
-         │    - Fiber Dump                                     │                                 │    - Text editor / IDE                              │
-         │    - Metrics                                        │                                 └─────────────────────────────────────────────────────┘
-         │        - prometheus                                 │                                                                                        
-         │    - Test (Just replys with a test message)         │                                                                                        
-         └─────────────────────────────────────────────────────┘                                              
-         
-         We want to give users the option to run a light weight server local to where their ZIO app is running that supports a few commands to aid monitoring and metrics of their application.
+<pre>                                                                                                                                                        
+    ┌─────────────────────┐           client -> server           ┌─────────────────────┐                   
+    │                     ◀━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫                     │                   
+    │     ZMX Server      │                                      │     ZMX Client      │                   
+    │                     ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━▶                     │                   
+    └─────────────────────┘           server -> client           └─────────────────────┘                   
+              ┃                                                             ┃                              
+                               (ZmxProtocol which is based                             
+              ┃                 on the Redis RESP protocol)                 ┃                              
+                                                                                                                     
+              ┃                                                             ┃                              
+                                                                                                          
+              ▼                                                             ▼                              
+ ┌───────────────────────────────────────────────┐    ┌─────────────────────────────────────────────────────┐
+ │- Respond to Command from client               │    │- Send Command to server                             │
+ │- User specified port server is to run on      │    │- User specified port server is running on           │
+ │- Always run on localhost where ZIO is running │    │- Client implementations planned:                    │
+ │- Supported Commands Planned:                  │    │    - CLI                                            │
+ │    - Fiber Dump                               │    │    - Text editor / IDE                              │
+ │    - Metrics                                  │    └─────────────────────────────────────────────────────┘
+ │        - prometheus                           │                                                           
+ │    - Test (Just replys with a test message)   │                                                                        
+ └───────────────────────────────────────────────┘                                             
+</pre>
+We want to give users the option to run a light weight server local to where their ZIO app is running that supports a few commands to aid monitoring and metrics of their application.
 
 ### Commands
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -5,31 +5,31 @@ title:  "About ZIO ZMX"
 
 # Monitoring, Metrics and Diagnostics for ZIO
 
-            ┌─────────────────────┐                               client -> server                            ┌─────────────────────┐                   
-            │                     ◀━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫                     │                   
-            │     ZMX Server      │                                                                           │     ZMX Client      │                   
-            │                     ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━▶                     │                   
-            └─────────────────────┘                               server -> client                            └─────────────────────┘                   
-                                                                                                                         ┃                              
-                      ┃                        (ZmxProtocol which is based on the Redis RESP protocol)                                                  
-                                                                                                                         ┃                              
-                      ┃                                                                                                                                 
-                                                                                                                         ┃                              
-                      ┃                                                                                                                                 
-                                                                                                                         ▼                              
-                      ▼                                                                                                                                 
-         ┌─────────────────────────────────────────────────────┐                                 ┌─────────────────────────────────────────────────────┐
-         │- Send Command to server                             │                                 │- Send Command to server                             │
-         │- User specified port server is to run on            │                                 │- User specified port server is running on           │
-         │- Always run on localhost where ZIO is running       │                                 │- Client implementations planned:                    │
-         │- Supported Commands Planned:                        │                                 │    - CLI                                            │
-         │    - Fiber Dump                                     │                                 │    - Text editor / IDE                              │
-         │    - Metrics                                        │                                 └─────────────────────────────────────────────────────┘
-         │        - prometheus                                 │                                                                                        
-         │    - Test (Just replys with a test message)         │                                                                                        
-         └─────────────────────────────────────────────────────┘                                              
-         
-         We want to give users the option to run a light weight server local to where their ZIO app is running that supports a few commands to aid monitoring and metrics of their application.
+<pre>                                                                                                                                                        
+    ┌─────────────────────┐           client -> server           ┌─────────────────────┐                   
+    │                     ◀━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫                     │                   
+    │     ZMX Server      │                                      │     ZMX Client      │                   
+    │                     ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━▶                     │                   
+    └─────────────────────┘           server -> client           └─────────────────────┘                   
+              ┃                                                             ┃                              
+                               (ZmxProtocol which is based                             
+              ┃                 on the Redis RESP protocol)                 ┃                              
+                                                                                                                     
+              ┃                                                             ┃                              
+                                                                                                          
+              ▼                                                             ▼                              
+ ┌───────────────────────────────────────────────┐    ┌─────────────────────────────────────────────────────┐
+ │- Respond to Command from client               │    │- Send Command to server                             │
+ │- User specified port server is to run on      │    │- User specified port server is running on           │
+ │- Always run on localhost where ZIO is running │    │- Client implementations planned:                    │
+ │- Supported Commands Planned:                  │    │    - CLI                                            │
+ │    - Fiber Dump                               │    │    - Text editor / IDE                              │
+ │    - Metrics                                  │    └─────────────────────────────────────────────────────┘
+ │        - prometheus                           │                                                           
+ │    - Test (Just replys with a test message)   │                                                                        
+ └───────────────────────────────────────────────┘                                             
+</pre>
+We want to give users the option to run a light weight server local to where their ZIO app is running that supports a few commands to aid monitoring and metrics of their application.
 
 ## Commands
 


### PR DESCRIPTION
Here I fixed error at ascii main diagram: server should respond 
to commands, not send. In addition reformat plot to be more
compact (just deletion of excessive spaces).