### PR TITLE
Fix `ZMXProtocol.Data.FiberDump` to be serialized as Array of Bulk Strings

### DIFF
--- a/docs/overview/diagnostics.md
+++ b/docs/overview/diagnostics.md
@@ -60,9 +60,12 @@ dump\r\n
 Response:
 ```
 *3\r\n
-+{fiber dump 1}\r\n
-+{fiber dump 2}\r\n
-+{fiber dump 3}\r\n
+$14\r\n
+{fiber dump 1}\r\n
+$14\r\n
+{fiber dump 2}\r\n
+$14\r\n
+{fiber dump 3}\r\n
 ```
 
 ### Metrics

--- a/src/main/scala/zio/zmx/diagnostics/parser/Parser.scala
+++ b/src/main/scala/zio/zmx/diagnostics/parser/Parser.scala
@@ -79,11 +79,11 @@ object Parser {
     case ZMXProtocol.Response.Success(data) =>
       data match {
         case executionMetrics: ZMXProtocol.Data.ExecutionMetrics =>
-          // TODO: Format of `ExecutionMetrics` serialized could be discussed and revisited.
+          // TODO: Format of `ExecutionMetrics` serialized could be discussed and revisited. See: https://github.com/zio/zio-zmx/issues/142
           Resp.BulkString(executionMetrics.toString).serialize
 
         case fiberDump: ZMXProtocol.Data.FiberDump =>
-          Resp.Array(fiberDump.dumps.map(Resp.SimpleString.apply)).serialize
+          Resp.Array(fiberDump.dumps.map(Resp.BulkString)).serialize
 
         case simple: ZMXProtocol.Data.Simple =>
           Resp.SimpleString(simple.message).serialize

--- a/src/test/scala/zio/zmx/diagnostics/parser/ParserSpec.scala
+++ b/src/test/scala/zio/zmx/diagnostics/parser/ParserSpec.scala
@@ -27,7 +27,7 @@ object ParserSpec extends DefaultRunnableSpec {
             )
             Parser.serialize(Response.Success(Data.FiberDump(dumps)))
           } {
-            equalTo(bytes("*3\r\n+{fiber dump 1}\r\n+{fiber dump 2}\r\n+{fiber dump 3}\r\n"))
+            equalTo(bytes("*3\r\n$14\r\n{fiber dump 1}\r\n$14\r\n{fiber dump 2}\r\n$14\r\n{fiber dump 3}\r\n"))
           }
         },
         test("Serializing a `Data.ExecutionMetrics` successful response") {


### PR DESCRIPTION
Fixes #143.