### PR TITLE
Replace listen methods by service dependency

### DIFF
--- a/src/main/scala/zio/zmx/MetricsAggregator.scala
+++ b/src/main/scala/zio/zmx/MetricsAggregator.scala
@@ -1,0 +1,123 @@
+package zio.zmx
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ThreadLocalRandom
+
+import zio.clock.Clock
+import zio.internal.RingBuffer
+import zio.zmx.metrics.Encoder
+import zio.{ Chunk, Fiber, RIO, Ref, Schedule, UIO, URIO, URLayer, ZIO, ZLayer, ZManaged }
+
+object MetricsAggregator {
+
+  sealed trait AddResult
+
+  object AddResult {
+    object Added   extends AddResult
+    object Ignored extends AddResult
+    object Dropped extends AddResult
+  }
+
+  trait Service {
+    def add(m: Metric[_]): UIO[AddResult]
+  }
+
+  /**
+   * Provides a metrics aggregator that uses a ring buffer for aggregating metrics into chunks of metrics.
+   */
+  def live(config: MetricsConfig): URLayer[Clock with MetricsSender[Chunk[Byte]], MetricsAggregator] =
+    ZLayer.fromManaged(
+      ZManaged.makeInterruptible(
+        for {
+          sender <- ZIO.access[MetricsSender[Chunk[Byte]]](_.get)
+          res    <- createRingBufferAggregator(config, sender)
+        } yield res
+      )(
+        _.asInstanceOf[RingBufferAggregator].release
+      )
+    )
+
+  def encodeMetric(metric: Metric[_]): Chunk[Byte] =
+    Chunk.fromArray(Encoder.encode(metric).getBytes(StandardCharsets.UTF_8))
+
+  // TODO: Maybe a chunk of metrics should be encoded into a single chunk of bytes.
+  //       -> Add line separators between the single metrics
+  def encodeMetrics(metrics: Chunk[Metric[_]]): Chunk[Chunk[Byte]] = metrics.map(encodeMetric)
+
+  private def createRingBufferAggregator(
+    config: MetricsConfig,
+    sender: MetricsSender.Service[Chunk[Byte]]
+  ): URIO[Clock, Service] =
+    for {
+      ring       <- ZIO.effectTotal(RingBuffer[Metric[_]](config.maximumSize))
+      aggregator <- Ref.make[Chunk[Metric[_]]](Chunk.empty)
+
+      collectFiber <- collectIo(config, ring, aggregator, sender).forever.forkDaemon
+
+    } yield new RingBufferAggregator(ring, collectFiber)
+
+  private def collectIo(
+    config: MetricsConfig,
+    ring: RingBuffer[Metric[_]],
+    aggregator: Ref[Chunk[Metric[_]]],
+    sender: MetricsSender.Service[Chunk[Byte]]
+  ): RIO[Clock, Unit] = {
+
+    val untilNCollected =
+      Schedule.fixed(config.pollRate) *>
+        Schedule.recurUntil[Chunk[Metric[_]]](_.size == config.bufferSize)
+
+    def poll: URIO[Clock, Chunk[Metric[_]]] =
+      UIO(ring.poll(Metric.Zero)).flatMap {
+        case Metric.Zero => aggregator.get
+        case m @ _       =>
+          aggregator.updateAndGet(_ :+ m) >>= { c =>
+            if (c.size < config.bufferSize) poll else ZIO.succeedNow(c)
+          }
+      }
+
+    def drain: UIO[Unit] =
+      UIO(ring.poll(Metric.Zero)).flatMap {
+        case Metric.Zero => ZIO.unit
+        case m @ _       => aggregator.updateAndGet(_ :+ m) *> drain
+      }
+
+    for {
+      polledMetrics <- poll.repeat(untilNCollected).timeout(config.timeout)
+      // drain only if polling did end because of a timeout
+      _             <- if (polledMetrics.isEmpty) drain else ZIO.succeedNow(())
+      metrics       <- aggregator.getAndUpdate(_ => Chunk.empty)
+      // TODO: Each metric is sent as a UDP datagram of its own! Is this really necessary?
+      //       I guess the original intent was to send groups of metrics at once.
+      //       However, the current code does not implement this.
+      groupedMetrics = metrics.grouped(config.bufferSize).flatMap(encodeMetrics).toSeq
+      _             <- ZIO.foreach(groupedMetrics)(sender.send(_))
+    } yield ()
+
+  }
+
+  private class RingBufferAggregator(
+    ring: RingBuffer[Metric[_]],
+    collectFiber: Fiber[Throwable, Nothing]
+  ) extends Service {
+
+    private def shouldSample(rate: Double): Boolean =
+      if (rate >= 1.0 || ThreadLocalRandom.current.nextDouble <= rate) true else false
+
+    private def shouldSample(metric: Metric[_]): Boolean = metric match {
+      case Metric.Counter(_, _, sampleRate, _)   => shouldSample(sampleRate)
+      case Metric.Histogram(_, _, sampleRate, _) => shouldSample(sampleRate)
+      case Metric.Timer(_, _, sampleRate, _)     => shouldSample(sampleRate)
+      case _                                     => true
+    }
+
+    override def add(metric: Metric[_]): UIO[AddResult] =
+      if (shouldSample(metric)) {
+        UIO(if (ring.offer(metric)) AddResult.Added else AddResult.Dropped)
+      } else {
+        ZIO.succeedNow(AddResult.Ignored)
+      }
+
+    val release: UIO[Unit] = collectFiber.interrupt.as(())
+  }
+}

--- a/src/main/scala/zio/zmx/MetricsSender.scala
+++ b/src/main/scala/zio/zmx/MetricsSender.scala
@@ -2,7 +2,7 @@ package zio.zmx
 
 import zio.zmx.metrics.UDPClient
 import zio.zmx.metrics.UDPClient.UDPClient
-import zio.{Chunk, TaskLayer, UIO, ZIO, ZLayer}
+import zio.{ Chunk, TaskLayer, UIO, ZIO, ZLayer }
 
 object MetricsSender {
 

--- a/src/main/scala/zio/zmx/MetricsSender.scala
+++ b/src/main/scala/zio/zmx/MetricsSender.scala
@@ -1,0 +1,23 @@
+package zio.zmx
+
+import zio.zmx.metrics.UDPClient
+import zio.zmx.metrics.UDPClient.UDPClient
+import zio.{Chunk, TaskLayer, UIO, ZIO, ZLayer}
+
+object MetricsSender {
+
+  trait Service[B] {
+    def send(b: B): UIO[Unit]
+  }
+
+  // thin adapter to the UDPClient service
+  def udpClientMetricsSender(config: MetricsConfig): TaskLayer[MetricsSender[Chunk[Byte]]] =
+    ZLayer.fromEffect {
+      (for {
+        udpClient <- ZIO.access[UDPClient](_.get)
+      } yield new Service[Chunk[Byte]] {
+        // TODO: What to do with the exceptions returned by udpClient.write()
+        override def send(b: Chunk[Byte]): UIO[Unit] = udpClient.write(b).either.as(())
+      }).provideLayer(UDPClient.live(config))
+    }
+}

--- a/src/test/scala/zio/MetricsServiceApp.scala
+++ b/src/test/scala/zio/MetricsServiceApp.scala
@@ -25,11 +25,11 @@ object MetricsServiceApp extends App {
 
   val config = MetricsConfig(maximumSize = 20, bufferSize = 5, timeout = 5.seconds, pollRate = 100.millis, None, None)
 
+
   def run(args: List[String]) = app.provideCustomLayer(Metrics.live(config)).exitCode
 
   val app: RIO[Console with Clock with Metrics, Unit] = for {
     metrics <- ZIO.access[Metrics](_.get)
-    fiber   <- metrics.listen()
     _       <- metrics.counter("test-zmx", 1.0, 1.0, Label("test", "zmx"))
     _       <- metrics.counter("test-zmx", 3.0, 1.0, Label("test", "zmx"))
     _       <- metrics.counter("test-zmx", 1.0, 1.0, Label("test", "zmx"))
@@ -39,7 +39,6 @@ object MetricsServiceApp extends App {
     b       <- metrics.counter("test-zmx", 2.0, 1.0, Label("test", "zmx"))
     _       <- putStrLn(s"send 7th item: $b")
     _       <- sleep(15.seconds)
-    _       <- fiber.interrupt
   } yield ()
 
 }

--- a/src/test/scala/zio/MetricsServiceApp.scala
+++ b/src/test/scala/zio/MetricsServiceApp.scala
@@ -25,7 +25,6 @@ object MetricsServiceApp extends App {
 
   val config = MetricsConfig(maximumSize = 20, bufferSize = 5, timeout = 5.seconds, pollRate = 100.millis, None, None)
 
-
   def run(args: List[String]) = app.provideCustomLayer(Metrics.live(config)).exitCode
 
   val app: RIO[Console with Clock with Metrics, Unit] = for {

--- a/src/test/scala/zio/PrometheusSpec.scala
+++ b/src/test/scala/zio/PrometheusSpec.scala
@@ -22,7 +22,7 @@ import zio.zmx._
 import zio.clock.Clock
 import zio.console._
 import io.prometheus.client.CollectorRegistry
-import io.prometheus.client.{Counter => PCounter, Histogram => PHistogram}
+import io.prometheus.client.{ Counter => PCounter, Histogram => PHistogram }
 import io.prometheus.client.exporter.common.TextFormat
 import io.prometheus.client.exporter.HTTPServer
 import java.io.StringWriter
@@ -116,12 +116,12 @@ object PrometheusSpec {
 
   def main(args: Array[String]): Unit = {
     val aggregationLayer = ZLayer.succeed(new MetricsAggregator.Service {
-      override def add(m: Metric[_]): UIO[MetricsAggregator.AddResult] = instrument(Chunk(m)).catchAll(e => {
+      override def add(m: Metric[_]): UIO[MetricsAggregator.AddResult] = instrument(Chunk(m)).catchAll { e =>
         ZIO.succeed(e.printStackTrace())
-      }).as(AddResult.Added)
+      }.as(AddResult.Added)
     })
-    val metricsLayer = aggregationLayer >>> Metrics.fromAggregator
-    val server = Runtime.default.unsafeRun(program.provideSomeLayer[Console with Clock](metricsLayer))
+    val metricsLayer     = aggregationLayer >>> Metrics.fromAggregator
+    val server           = Runtime.default.unsafeRun(program.provideSomeLayer[Console with Clock](metricsLayer))
     Thread.sleep(60000)
     server.stop()
   }

--- a/src/test/scala/zio/ServiceSpec.scala
+++ b/src/test/scala/zio/ServiceSpec.scala
@@ -16,12 +16,14 @@
 
 package zio
 
+import zio.clock.Clock
+import zio.console.Console
+import zio.duration._
 import zio.test.Assertion._
 import zio.test._
+import zio.test.environment.TestClock
 import zio.zmx.Metrics._
-import zio.duration._
 import zio.zmx._
-import zio.clock.Clock
 
 object ServiceSpec extends DefaultRunnableSpec {
 
@@ -34,46 +36,61 @@ object ServiceSpec extends DefaultRunnableSpec {
     port = None
   )
 
+  def testMetricsServiceByCheckingEmittedChunks[E](label: String)(
+    assertion: Queue[Chunk[Byte]] => ZIO[TestClock with Clock with Console with Metrics, E, TestResult]
+  ): ZSpec[TestClock with Clock with Console, E] =
+    testM(label) {
+      for {
+        // collects the published chunks of bytes
+        queue <- ZQueue.unbounded[Chunk[Byte]]
+
+        senderLayer = ZLayer.succeed(new MetricsSender.Service[Chunk[Byte]] {
+                        override def send(b: Chunk[Byte]): UIO[Unit] = queue.offer(b).as(())
+                      })
+
+        metricsLayer =
+          ZLayer.identity[Clock] ++ senderLayer >>> MetricsAggregator.live(config) >>> Metrics.fromAggregator
+
+        testResult <- assertion(queue)
+                        .provideSomeLayer[TestClock with Clock with Console](metricsLayer)
+      } yield testResult
+    }
+
   val testSendMetricsLive: RIO[Metrics, TestResult] = for {
     b <- counter("safe-zmx", 2.0, 1.0)
   } yield assert(b)(equalTo(true))
 
-  val testCollectMetricsLive: RIO[Metrics, TestResult] = for {
-    _              <- counter("test-zmx", 1.0, 1.0, Label("test", "zmx"))
-    _              <- counter("test-zmx", 3.0, 1.0, Label("test", "zmx"))
-    _              <- counter("test-zmx", 1.0, 1.0, Label("test", "zmx"))
-    _              <- counter("test-zmx", 5.0, 1.0, Label("test", "zmx"))
-    _              <- counter("test-zmx", 4.0, 1.0, Label("test", "zmx"))
-    _              <- counter("test-zmx", 2.0, 1.0, Label("test", "zmx"))
-    queue          <- ZQueue.unbounded[Chunk[Metric[_]]]
-    _              <- listen(metrics => queue.offer(metrics).as(metrics.map(_ => 1L)))
-    emittedMetrics <- queue.take
-  } yield assert(emittedMetrics)(
-    equalTo(
-      Chunk(
-        Metric.Counter("test-zmx", 1.0, 1.0, Chunk(Label("test", "zmx"))),
-        Metric.Counter("test-zmx", 3.0, 1.0, Chunk(Label("test", "zmx"))),
-        Metric.Counter("test-zmx", 1.0, 1.0, Chunk(Label("test", "zmx"))),
-        Metric.Counter("test-zmx", 5.0, 1.0, Chunk(Label("test", "zmx"))),
-        Metric.Counter("test-zmx", 4.0, 1.0, Chunk(Label("test", "zmx")))
+  def testCollectMetricsLive(queue: Queue[Chunk[Byte]]): RIO[TestClock with Metrics, TestResult] =
+    for {
+      // send one more counter event than the aggregation size
+      _              <- ZIO.foreach((1 to config.bufferSize + 1).toList)(i =>
+                          counter("test-zmx", i.toDouble, 1.0, Label("test", "zmx"))
+                        )
+      _              <- TestClock.adjust(config.pollRate)
+      emittedMetrics <- queue.takeAll
+    } yield assert(emittedMetrics)(
+      equalTo(
+        // the last counter event is still in the aggregator
+        (1 to config.bufferSize)
+          .map(i => Metric.Counter("test-zmx", i.toDouble, 1.0, Chunk(Label("test", "zmx"))))
+          .map(MetricsAggregator.encodeMetric)
+          .toList
       )
     )
-  )
 
-  val testSendOnTimeout: RIO[Metrics, TestResult] = for {
-    queue          <- ZQueue.unbounded[Chunk[Metric[_]]]
-    _              <- listen(metrics => queue.offer(metrics).as(metrics.map(_ => 1L)))
+  def testSendOnTimeout(queue: Queue[Chunk[Byte]]): RIO[TestClock with Metrics, TestResult] = for {
     _              <- counter("test-zmx", 1.0, 1.0, Label("test", "zmx"))
     _              <- counter("test-zmx", 3.0, 1.0, Label("test", "zmx"))
     _              <- counter("test-zmx", 5.0, 1.0, Label("test", "zmx"))
-    emittedMetrics <- queue.take
+    _              <- TestClock.adjust(config.timeout)
+    emittedMetrics <- queue.takeAll
   } yield assert(emittedMetrics)(
     equalTo(
-      Chunk(
+      List(
         Metric.Counter("test-zmx", 1.0, 1.0, Chunk(Label("test", "zmx"))),
         Metric.Counter("test-zmx", 3.0, 1.0, Chunk(Label("test", "zmx"))),
         Metric.Counter("test-zmx", 5.0, 1.0, Chunk(Label("test", "zmx")))
-      )
+      ).map(MetricsAggregator.encodeMetric)
     )
   )
 
@@ -81,16 +98,16 @@ object ServiceSpec extends DefaultRunnableSpec {
     suite("Service Spec")(
       suite("Using the Service directly")(
         testM("does not leak sockets") {
-          Metrics.live(config).build.use(_ => ZIO.succeed(assertCompletes))
+          MetricsSender.udpClientMetricsSender(config).build.use(_ => ZIO.succeed(assertCompletes))
         } @@ TestAspect.nonFlaky(1000),
-        testM("send returns true") {
-          testSendMetricsLive.provideSomeLayer(Metrics.live(config))
+        testMetricsServiceByCheckingEmittedChunks("send returns true") { _ =>
+          testSendMetricsLive
         },
-        testM("Send on 5") {
-          testCollectMetricsLive.provideLayer(Clock.live >>> Metrics.live(config.copy(timeout = 30.seconds)))
+        testMetricsServiceByCheckingEmittedChunks("Send on 5") { queue =>
+          testCollectMetricsLive(queue)
         },
-        testM("Send 3 on timeout") {
-          testSendOnTimeout.provideLayer(Clock.live >>> Metrics.live(config))
+        testMetricsServiceByCheckingEmittedChunks("Send 3 on timeout") { queue =>
+          testSendOnTimeout(queue)
         }
       )
     )


### PR DESCRIPTION
The current `Metrics` service provides `listen` methods that attach consumers of the created metrics (cf. https://github.com/zio/zio-zmx/issues/154). These listen methods are replaced my service dependency.

The current metrics service functionality is split into 3 separate service:

1. `Metrics` service
2. `MetricsAggregator` service
3. `MetricsSender` service

This split allows flexible setups of different "metrics systems". There can be different aggregator and sender implementations. For example aggregators could filter some metrics or optimize for transport costs. There could be even composite aggregators / senders if metrics should be send to different destinations.

The current functionality is refactored into the new structure with minor behavior improvements of the current ring buffer aggregation / collection logic. The current aggregation logic did poll only a single metric every `config.pollRate`. The new implementation possibly polls more than one metrics at each rate. The second change is that the ring buffer is drained only if polling ended because of a timeout. Finally, filtering metrics because of their sampling rate is done before a metric is added to the ring buffer. The old implementation sampled metrics when they where aggregated.