### PR TITLE
Replaced uzhttp with zio-http

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,20 +31,27 @@ inThisBuild(
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
-val zioVersion = "1.0.9"
+val zioVersion     = "1.0.9"
+val zioHttpVersion = "1.0.0.0-RC17"
 
 libraryDependencies ++= Seq(
-  "dev.zio"      %% "zio"          % zioVersion,
-  "dev.zio"      %% "zio-nio"      % "1.0.0-RC9" % "test",
-  "dev.zio"      %% "zio-test"     % zioVersion  % "test",
-  "dev.zio"      %% "zio-test-sbt" % zioVersion  % "test",
-  "org.polynote" %% "uzhttp"       % "0.2.7"     % "test",
-  "dev.zio"      %% "zio-json"     % "0.1"       % "test"
-)
+  "dev.zio" %% "zio" % zioVersion
+) ++ Seq(
+  "dev.zio" %% "zio-nio"      % "1.0.0-RC10",
+  "dev.zio" %% "zio-test"     % zioVersion,
+  "dev.zio" %% "zio-test-sbt" % zioVersion,
+  "io.d11"  %% "zhttp"        % zioHttpVersion,
+  "dev.zio" %% "zio-json"     % "0.1.5"
+).map(_ % Test)
 
 testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
 
 resolvers += Resolver.sonatypeRepo("snapshots")
+
+lazy val docsModuleLibs = Seq(
+  "dev.zio" %% "zio"   % zioVersion,
+  "io.d11"  %% "zhttp" % zioHttpVersion
+)
 
 lazy val root =
   (project in file("."))
@@ -61,10 +68,7 @@ lazy val examples =
     )
     .settings(
       publish / skip := true,
-      libraryDependencies ++= Seq(
-        "dev.zio"      %% "zio"    % zioVersion,
-        "org.polynote" %% "uzhttp" % "0.2.7"
-      )
+      libraryDependencies ++= docsModuleLibs
     )
     .dependsOn(root)
 
@@ -82,10 +86,7 @@ lazy val docs = project
     publish / skip := true,
     moduleName := "zio.zmx-docs",
     scalacOptions -= "-Yno-imports",
-    libraryDependencies ++= Seq(
-      "dev.zio"      %% "zio"    % zioVersion,
-      "org.polynote" %% "uzhttp" % "0.2.7"
-    ),
+    libraryDependencies ++= docsModuleLibs,
     ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(root),
     ScalaUnidoc / unidoc / target := (LocalRootProject / baseDirectory).value / "website" / "static" / "api",
     cleanFiles += (ScalaUnidoc / unidoc / target).value,

--- a/docs/metrics/prometheus.md
+++ b/docs/metrics/prometheus.md
@@ -95,78 +95,75 @@ mySet{token="myKey-12"} 10.0 1623589839194
 ## Serving Prometheus metrics
 
 ```scala mdoc:invisible
-import java.net.InetSocketAddress
-import uzhttp._
-import uzhttp.server.Server
+import io.netty.handler.codec.http.{ HttpHeaderNames, HttpHeaderValues }
+
+import zhttp.http._
+import zhttp.http.Method.GET
+import zhttp.service.Server
 
 import zio._
-import zio.console._
+import zio.console.{ getStrLn, putStrLn }
+
 import zio.zmx.MetricSnapshot.Prometheus
 import zio.zmx.prometheus.PrometheusClient
 
 import zio.zmx.example.InstrumentedSample
-
-val instrumentedSample = new InstrumentedSample() {}
 ```
 
-ZMX provides a prometheus client that can be used to produce the prometheus encoded metric state 
+ZMX provides a Prometheus client that can be used to produce the Prometheus-encoded metric state 
 upon request. The state is encoded in the `Prometheus` case class and the single attribute of 
-type `String` holds the prometheus encoded metric state. 
+type `String` holds the encoded value. 
 
-So, to retrieve the prometheus encoded state, the application can simply use 
-```scala mdoc:silent
-val encoded = PrometheusClient.snapshot
-val content = encoded.map(_.value)
-```
-
-In our example application we use [uzHttp](https://github.com/polynote/uzhttp) to quickly define 
-a simple server that can serve the metric state via http. In one of the next minor releases we 
-will switch the example application to use [zio-http](https://github.com/dream11/zio-http).
+In our example application, we use [zio-http](https://github.com/dream11/zio-http) to quickly define 
+a simple server that can serve the metric state via http.
 
 ```scala mdoc:silent
-object path {
-  def unapply(req: Request): Option[String] =
-    Some(req.uri.getPath)
+val contentTypeHtml = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_HTML)
+
+val httpApp = Http.collectM[Request] {
+  case GET -> Root =>
+    val html = htmlResponseOf(
+      """<html>
+        |<title>Simple Server</title>
+        |<body>
+        |<p><a href="/metrics">Metrics</a></p>
+        |<p><a href="/json">Json</a></p>
+        |</body
+        |</html>""".stripMargin
+    )
+    ZIO.succeed(html)
+  case GET -> Root / "metrics" =>
+    // retrieve the Prometheus-encoded state and transform it to a HTTP response
+    PrometheusClient.snapshot.map { prom =>
+      Response.text(prom.value)
+    }
 }
 
-val server = Server
-  .builder(new InetSocketAddress("0.0.0.0", 8080))
-  .handleSome {
-    case path("/")        =>
-      ZIO.succeed(
-        Response.html(
-          """<html>
-            |<title>Simple Server</title>
-            |<body>
-            |<p><a href="/metrics">Metrics</a></p>
-            |<p><a href="/json">Json</a></p>
-            |</body
-            |</html>""".stripMargin
-        )
-      )
-    case path("/metrics") =>
-      PrometheusClient.snapshot.map { case Prometheus(value) =>
-        Response.plain(value)
-      }
-  }
-  .serve
-  .use(s => s.awaitShutdown)
+def htmlResponseOf(markup: String): UResponse =
+  Response.http(
+    headers = List(contentTypeHtml),
+    content = HttpData.CompleteData(
+      Chunk.fromArray(markup.getBytes(HTTP_CHARSET))
+    )
+  )
 ```
 
 Now, using the HTTP server and the [instrumentation examples](example.md) we can create an effect 
 that simply runs the sample effects with their instrumentation until the user presses any key. 
 
 ```scala mdoc:silent
+val port = 8080
+val instrumentedSample = new InstrumentedSample() {}
 val execute =
   for {
-    s <- server.fork
+    s <- Server.start(port, httpApp).fork
     p <- instrumentedSample.program.fork
     _ <- putStrLn("Press Any Key") *> getStrLn.orDie *> s.interrupt *> p.interrupt
   } yield ExitCode.success
 ```    
 
-Finally, within a `ZIO.App` we can override the run method, which is now simply the execute 
-method with a Prometheus client provided in it´s environment:
+Finally, within a `ZIO.App` we override and implement the `run` method, which is now simply a call to the `execute` 
+method with a Prometheus client provided in its environment:
 
 ```scala mdoc:silent
 def run(args: List[String]): URIO[ZEnv, ExitCode] =

--- a/src/test/scala/zio/zmx/diagnostics/ZMXClientSpec.scala
+++ b/src/test/scala/zio/zmx/diagnostics/ZMXClientSpec.scala
@@ -68,7 +68,7 @@ object ZMXClientSpec extends DefaultRunnableSpec {
               _   <- buf.flip
               req <- buf.withJavaBuffer(b => ZIO.succeed(UTF_8.decode(b).toString))
 
-              _    <- client.write(bytes("*0\r\n"))
+              _    <- client.writeChunks(List(bytes("*0\r\n")))
               _    <- client.close
               exit <- clientFiber.await
               resp  = exit.getOrElse(_ => "NOPE")


### PR DESCRIPTION
WIP:

1. Trying to upgrade zio-nio to the latest 1.0.0-RC11. It appears 1.0.0-RC11 has made a few breaking changes from 1.0.0-RC10. I'm having one last problem to get it sorted. For now, I upgraded zio-nio to 1.0.0-RC10.
2. The `ZmxSampleApp` seems to be in a non-working state. I ran the test app from the Main branch (without my changes) and it failed. Something to do with the `statsd` client. I'll spend more time tomorrow to troubleshoot.