### PR TITLE
added scala 3 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.12.14', '2.13.6', "3.0.1"]
+        scala: ['2.12.14', '2.13.6', "3.0.2"]
     steps:
     - uses: actions/checkout@v2.3.4
     - uses: olafurpg/setup-scala@v10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.12.14', '2.13.6']
+        scala: ['2.12.14', '2.13.6', "3.0.1"]
     steps:
     - uses: actions/checkout@v2.3.4
     - uses: olafurpg/setup-scala@v10

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import BuildHelper._
-
 inThisBuild(
   List(
     organization := "dev.zio",
@@ -39,6 +38,7 @@ val boopickleVerison = "1.4.0"
 val fansiVersion     = "0.2.14"
 val laminarVersion   = "0.13.1"
 val laminextVersion  = "0.13.10"
+val zioJsonVersion   = "0.2.0-M1"
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 
@@ -57,11 +57,10 @@ lazy val core =
       stdSettings("zio.zmx"),
       libraryDependencies ++= Seq(
         "dev.zio" %%% "zio"          % zioVersion,
-        "dev.zio"  %% "zio-nio"      % "1.0.0-RC9"    % Test,
         "dev.zio"  %% "zio-test"     % zioVersion     % Test,
         "dev.zio"  %% "zio-test-sbt" % zioVersion     % Test,
         "io.d11"   %% "zhttp"        % zioHttpVersion % Test,
-        "dev.zio"  %% "zio-json"     % "0.1"          % Test
+        "dev.zio"  %% "zio-json"     % zioJsonVersion % Test
       )
     )
     .settings(buildInfoSettings("zio.zmx"))
@@ -74,7 +73,7 @@ lazy val client =
   crossProject(JSPlatform, JVMPlatform)
     .in(file("client"))
     .settings(
-      crossScalaVersions := Seq(Scala213),
+      crossScalaVersions := Seq(Scala213, ScalaDotty),
       stdSettings("zio.zmx.client"),
       libraryDependencies ++= Seq(
         "dev.zio"   %%% "zio"       % zioVersion,
@@ -82,7 +81,7 @@ lazy val client =
       )
     )
     .jvmSettings(
-      crossScalaVersions := Seq(Scala213),
+      crossScalaVersions := Seq(Scala213, ScalaDotty),
       libraryDependencies ++= Seq(
         "dev.zio" %% "zio"   % zioVersion,
         "io.d11"  %% "zhttp" % zioHttpVersion
@@ -91,7 +90,7 @@ lazy val client =
       run / javaOptions += "-Djava.net.preferIPv4Stack=true"
     )
     .jsSettings(
-      crossScalaVersions := Seq(Scala213),
+      crossScalaVersions := Seq(Scala213, ScalaDotty),
       libraryDependencies ++= Seq(
         "dev.zio"           %%% "zio"             % zioVersion,
         "com.raquo"         %%% "laminar"         % laminarVersion,

--- a/client/js/src/main/scala/zio/zmx/client/frontend/AppState.scala
+++ b/client/js/src/main/scala/zio/zmx/client/frontend/AppState.scala
@@ -84,16 +84,18 @@ object AppState {
       val subscribe: ByteBuffer = Pickle.intoBytes[ClientMessage](ClientMessage.subscribe)
       ws.sendOne(subscribe.arrayBuffer())
     },
-    ws.received.map(buf => {
+    ws.received.map { buf =>
       // https://github.com/suzaku-io/boopickle/issues/170 Pickle/Unpickle derivation doesnt work with sealed traits in scala 3
       val wrappedBuf = TypedArrayBuffer.wrap(buf)
       import MetricsMessage._
-      Unpickle[GaugeChange].tryFromBytes(wrappedBuf)
-        .orElse( Unpickle[CounterChange].tryFromBytes(wrappedBuf))
-        .orElse( Unpickle[HistogramChange].tryFromBytes(wrappedBuf))
-        .orElse( Unpickle[SummaryChange].tryFromBytes(wrappedBuf))
-        .orElse( Unpickle[SetChange].tryFromBytes(wrappedBuf)).get
-    }) --> { msg =>
+      Unpickle[GaugeChange]
+        .tryFromBytes(wrappedBuf)
+        .orElse(Unpickle[CounterChange].tryFromBytes(wrappedBuf))
+        .orElse(Unpickle[HistogramChange].tryFromBytes(wrappedBuf))
+        .orElse(Unpickle[SummaryChange].tryFromBytes(wrappedBuf))
+        .orElse(Unpickle[SetChange].tryFromBytes(wrappedBuf))
+        .get
+    } --> { msg =>
       //println(msg.toString())
       messages.emit(msg)
     },

--- a/client/js/src/main/scala/zio/zmx/client/frontend/AppState.scala
+++ b/client/js/src/main/scala/zio/zmx/client/frontend/AppState.scala
@@ -84,7 +84,16 @@ object AppState {
       val subscribe: ByteBuffer = Pickle.intoBytes[ClientMessage](ClientMessage.subscribe)
       ws.sendOne(subscribe.arrayBuffer())
     },
-    ws.received.map(buf => Unpickle[MetricsMessage].fromBytes(TypedArrayBuffer.wrap(buf))) --> { msg =>
+    ws.received.map(buf => {
+      // https://github.com/suzaku-io/boopickle/issues/170 Pickle/Unpickle derivation doesnt work with sealed traits in scala 3
+      val wrappedBuf = TypedArrayBuffer.wrap(buf)
+      import MetricsMessage._
+      Unpickle[GaugeChange].tryFromBytes(wrappedBuf)
+        .orElse( Unpickle[CounterChange].tryFromBytes(wrappedBuf))
+        .orElse( Unpickle[HistogramChange].tryFromBytes(wrappedBuf))
+        .orElse( Unpickle[SummaryChange].tryFromBytes(wrappedBuf))
+        .orElse( Unpickle[SetChange].tryFromBytes(wrappedBuf)).get
+    }) --> { msg =>
       //println(msg.toString())
       messages.emit(msg)
     },

--- a/client/js/src/main/scala/zio/zmx/client/frontend/views/DiagramView.scala
+++ b/client/js/src/main/scala/zio/zmx/client/frontend/views/DiagramView.scala
@@ -99,7 +99,7 @@ object DiagramView {
                 }
               case _                                        => ()
             }
-          case _                                   => ()
+          case null                                => ()
         }),
         cls := "bg-gray-900 text-gray-50 rounded my-3 p-3",
         span(

--- a/client/js/src/main/scala/zio/zmx/client/frontend/views/ScalaDateAdapter.scala
+++ b/client/js/src/main/scala/zio/zmx/client/frontend/views/ScalaDateAdapter.scala
@@ -17,61 +17,61 @@ object ScalaDateAdapter {
 
   object TimeUnit {
 
-    final case object DateTime extends TimeUnit {
+    case object DateTime extends TimeUnit {
       val name: String          = "datetime"
       val duration: Duration    = 1.millis
       val fmt: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd-HH:mm:ss.SSS")
     }
 
-    final case object MilliSecond extends TimeUnit {
+    case object MilliSecond extends TimeUnit {
       val name: String          = "millisecond"
       val duration: Duration    = 1.millis
       val fmt: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd-HH:mm:ss.SSS")
     }
 
-    final case object Second extends TimeUnit {
+    case object Second extends TimeUnit {
       val name: String          = "second"
       val duration: Duration    = 1.second
       val fmt: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd-HH:mm:ss")
     }
 
-    final case object Minute extends TimeUnit {
+    case object Minute extends TimeUnit {
       val name: String          = "minute"
       val duration: Duration    = 1.minute
       val fmt: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd-HH:mm")
     }
 
-    final case object Hour extends TimeUnit {
+    case object Hour extends TimeUnit {
       val name: String          = "hour"
       val duration: Duration    = 1.hour
       val fmt: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd-HH")
     }
 
-    final case object Day extends TimeUnit {
+    case object Day extends TimeUnit {
       val name: String          = "day"
       val duration: Duration    = 1.day
       val fmt: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd")
     }
 
-    final case object Week extends TimeUnit {
+    case object Week extends TimeUnit {
       val name: String          = "week"
       val duration: Duration    = Day.duration * 7
       val fmt: SimpleDateFormat = new SimpleDateFormat("yyyy-ww")
     }
 
-    final case object Month extends TimeUnit {
+    case object Month extends TimeUnit {
       val name: String          = "month"
       val duration: Duration    = Day.duration * 30
       val fmt: SimpleDateFormat = new SimpleDateFormat("yyyy-MM")
     }
 
-    final case object Quarter extends TimeUnit {
+    case object Quarter extends TimeUnit {
       val name                  = "quarter"
       val duration              = Month.duration * 3
       val fmt: SimpleDateFormat = Month.fmt
     }
 
-    final case object Year extends TimeUnit {
+    case object Year extends TimeUnit {
       val name                  = "year"
       val duration              = Month.duration * 12
       val fmt: SimpleDateFormat = new SimpleDateFormat("yyyy")

--- a/core/jvm/src/main/scala/zio/zmx/diagnostics/ZMXClient.scala
+++ b/core/jvm/src/main/scala/zio/zmx/diagnostics/ZMXClient.scala
@@ -64,6 +64,6 @@ object ZMXClient {
    * Generate message to send to server
    */
   def generateRespCommand(args: Chunk[String]): Chunk[Byte] =
-    Resp.Array(args.map(Resp.BulkString)).serialize
+    Resp.Array(args.map(Resp.BulkString.apply(_))).serialize
 
 }

--- a/core/jvm/src/main/scala/zio/zmx/diagnostics/nio/Selector.scala
+++ b/core/jvm/src/main/scala/zio/zmx/diagnostics/nio/Selector.scala
@@ -16,7 +16,6 @@
 
 package zio.zmx.diagnostics.nio
 
-import com.github.ghik.silencer.silent
 import zio.IO
 
 import java.io.IOException
@@ -27,7 +26,7 @@ class Selector private (val selector: JSelector) {
 
   val selectedKeys: IO[ClosedSelectorException, Set[SelectionKey]] =
     IO.effect(selector.selectedKeys())
-      .map(_.asScala.toSet[JSelectionKey].map(new SelectionKey(_)): @silent("JavaConverters"))
+      .map(_.asScala.toSet[JSelectionKey].map(new SelectionKey(_)))
       .refineToOrDie[ClosedSelectorException]
 
   def removeKey(key: SelectionKey): IO[ClosedSelectorException, Unit] =

--- a/core/jvm/src/main/scala/zio/zmx/diagnostics/package.scala
+++ b/core/jvm/src/main/scala/zio/zmx/diagnostics/package.scala
@@ -1,6 +1,5 @@
 package zio.zmx
 
-import com.github.ghik.silencer.silent
 import zio._
 import zio.internal.Platform
 import zio.Supervisor.Propagation
@@ -16,7 +15,7 @@ package object diagnostics {
         Platform.newConcurrentSet[Fiber.Runtime[Any, Any]]()
 
       val value: UIO[Set[Fiber.Runtime[Any, Any]]] =
-        UIO.succeedNow(fibers.asScala.toSet: @silent("JavaConverters"))
+        UIO.succeedNow(fibers.asScala.toSet)
 
       def unsafeOnStart[R, E, A](
         environment: R,

--- a/core/jvm/src/main/scala/zio/zmx/diagnostics/parser/Parser.scala
+++ b/core/jvm/src/main/scala/zio/zmx/diagnostics/parser/Parser.scala
@@ -83,7 +83,7 @@ object Parser {
           Resp.BulkString(executionMetrics.render).serialize
 
         case fiberDump: Message.Data.FiberDump =>
-          Resp.Array(fiberDump.dumps.map(Resp.BulkString)).serialize
+          Resp.Array(fiberDump.dumps.map(Resp.BulkString.apply(_))).serialize
 
         case simple: Message.Data.Simple =>
           Resp.SimpleString(simple.message).serialize

--- a/core/jvm/src/main/scala/zio/zmx/diagnostics/parser/Resp.scala
+++ b/core/jvm/src/main/scala/zio/zmx/diagnostics/parser/Resp.scala
@@ -130,7 +130,7 @@ private[zmx] object Resp {
   }
 
   /** RESP Null */
-  final case object NoValue extends RespValue {
+  case object NoValue extends RespValue {
     override def serialize: Chunk[Byte] = {
       val NullCount: Chunk[Byte] = Chunk('-', '1')
       /*
@@ -161,8 +161,8 @@ private[zmx] object Resp {
   final case class InvalidInteger(text: String)          extends ParsingError
   final case class InvalidSize(size: Int)                extends ParsingError
   final case class UnknownHeader(byte: Byte)             extends ParsingError
-  final case object MalformedData                        extends ParsingError
-  final case object UnexpectedEndOfData                  extends ParsingError
+  case object MalformedData                              extends ParsingError
+  case object UnexpectedEndOfData                        extends ParsingError
 
   /** RESP parser */
   def parse(data: Chunk[Byte]): IO[ParsingError, RespValue] = {

--- a/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentHistogram.scala
+++ b/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentHistogram.scala
@@ -26,12 +26,12 @@ object ConcurrentHistogram {
     new ConcurrentHistogram {
       private[this] val values     = new AtomicReferenceArray[Long](bounds.length + 1)
       private[this] val boundaries = Array.ofDim[Double](bounds.length)
-      private[this] val count      = new LongAdder
-      private[this] val sum        = new DoubleAdder
+      private[this] val count0     = new LongAdder
+      private[this] val sum0       = new DoubleAdder
       private[this] val size       = bounds.length
       bounds.sorted.zipWithIndex.foreach { case (n, i) => boundaries(i) = n }
 
-      def count(): Long            = count.longValue()
+      def count(): Long            = count0.longValue()
 
       // Insert the value into the right bucket with a binary search
       def observe(value: Double): Unit = {
@@ -48,8 +48,8 @@ object ConcurrentHistogram {
           }
         }
         values.getAndUpdate(from, _ + 1L)
-        count.increment()
-        sum.add(value)
+        count0.increment()
+        sum0.add(value)
         ()
       }
 
@@ -67,6 +67,6 @@ object ConcurrentHistogram {
         builder.result()
       }
 
-      def sum(): Double = sum.doubleValue()
+      def sum(): Double = sum0.doubleValue()
     }
 }

--- a/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentHistogram.scala
+++ b/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentHistogram.scala
@@ -24,14 +24,14 @@ object ConcurrentHistogram {
 
   def manual(bounds: Chunk[Double]): ConcurrentHistogram =
     new ConcurrentHistogram {
-      private[this] val values     = new AtomicReferenceArray[Long](bounds.length + 1)
-      private[this] val boundaries = Array.ofDim[Double](bounds.length)
-      private[this] val count0     = new LongAdder
-      private[this] val sum0       = new DoubleAdder
-      private[this] val size       = bounds.length
+      private val values         = new AtomicReferenceArray[Long](bounds.length + 1)
+      private val boundaries     = Array.ofDim[Double](bounds.length)
+      private val count0         = new LongAdder
+      private val sum0           = new DoubleAdder
+      private val size           = bounds.length
       bounds.sorted.zipWithIndex.foreach { case (n, i) => boundaries(i) = n }
 
-      def count(): Long            = count0.longValue()
+      override def count(): Long = count0.longValue()
 
       // Insert the value into the right bucket with a binary search
       def observe(value: Double): Unit = {

--- a/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSetCount.scala
+++ b/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSetCount.scala
@@ -19,7 +19,7 @@ object ConcurrentSetCount {
 
   def manual(): ConcurrentSetCount =
     new ConcurrentSetCount {
-      private[this] val count0  = new LongAdder
+      private[this] val count0 = new LongAdder
       private[this] val values = new ConcurrentHashMap[String, LongAdder]
 
       def count(): Long = count0.longValue()
@@ -35,7 +35,7 @@ object ConcurrentSetCount {
         slot match {
           case la: LongAdder =>
             la.increment()
-          case null =>
+          case null          =>
         }
       }
 

--- a/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSetCount.scala
+++ b/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSetCount.scala
@@ -19,8 +19,8 @@ object ConcurrentSetCount {
 
   def manual(): ConcurrentSetCount =
     new ConcurrentSetCount {
-      private[this] val count0 = new LongAdder
-      private[this] val values = new ConcurrentHashMap[String, LongAdder]
+      private val count0 = new LongAdder
+      private val values = new ConcurrentHashMap[String, LongAdder]
 
       def count(): Long = count0.longValue()
 

--- a/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSetCount.scala
+++ b/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSetCount.scala
@@ -19,13 +19,13 @@ object ConcurrentSetCount {
 
   def manual(): ConcurrentSetCount =
     new ConcurrentSetCount {
-      private[this] val count  = new LongAdder
+      private[this] val count0  = new LongAdder
       private[this] val values = new ConcurrentHashMap[String, LongAdder]
 
-      def count(): Long = count.longValue()
+      def count(): Long = count0.longValue()
 
       def observe(word: String): Unit = {
-        count.increment()
+        count0.increment()
         var slot = values.get(word)
         if (slot eq null) {
           val cnt = new LongAdder
@@ -35,7 +35,7 @@ object ConcurrentSetCount {
         slot match {
           case la: LongAdder =>
             la.increment()
-          case _             =>
+          case null =>
         }
       }
 

--- a/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSummary.scala
+++ b/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSummary.scala
@@ -32,18 +32,18 @@ object ConcurrentSummary {
   def manual(maxSize: Int, maxAge: Duration, error: Double, quantiles: Chunk[Double]): ConcurrentSummary =
     new ConcurrentSummary {
       private[this] val values          = new ConcurrentLinkedDeque[(java.time.Instant, Double)]
-      private[this] val count           = new LongAdder
+      private[this] val count0          = new LongAdder
       private[this] val currentCount    = new LongAdder
-      private[this] val sum             = new DoubleAdder
+      private[this] val sum0            = new DoubleAdder
       private[this] val sortedQuantiles = quantiles.sorted(dblOrdering)
 
       override def toString = s"ConcurrentSummary.manual(${count()}, ${sum()})"
 
       def count(): Long =
-        count.longValue
+        count0.longValue
 
       def sum(): Double =
-        sum.doubleValue
+        sum0.doubleValue
 
       // Just before the Snapshot we filter out all values older than maxAge
       def snapshot(now: java.time.Instant): Chunk[(Double, Option[Double])] = {
@@ -72,8 +72,8 @@ object ConcurrentSummary {
         }
         values.add((t, value))
 
-        count.increment()
-        sum.add(value)
+        count0.increment()
+        sum0.add(value)
         ()
       }
 
@@ -129,10 +129,10 @@ object ConcurrentSummary {
         val resolved = sortedQuantiles match {
           case e if e.isEmpty => Chunk.empty
           case c              =>
-            sortedQuantiles.tail
+            (sortedQuantiles.tail
               .foldLeft(Chunk(get(None, 0, c.head, sortedSamples))) { case (cur, q) =>
                 cur ++ Chunk(get(cur.head.value, cur.head.consumed, q, cur.head.rest))
-              }
+              })
         }
 
         resolved.map(rq => (rq.quantile, rq.value))

--- a/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSummary.scala
+++ b/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSummary.scala
@@ -31,11 +31,11 @@ object ConcurrentSummary {
 
   def manual(maxSize: Int, maxAge: Duration, error: Double, quantiles: Chunk[Double]): ConcurrentSummary =
     new ConcurrentSummary {
-      private[this] val values          = new ConcurrentLinkedDeque[(java.time.Instant, Double)]
-      private[this] val count0          = new LongAdder
-      private[this] val currentCount    = new LongAdder
-      private[this] val sum0            = new DoubleAdder
-      private[this] val sortedQuantiles = quantiles.sorted(dblOrdering)
+      private val values          = new ConcurrentLinkedDeque[(java.time.Instant, Double)]
+      private val count0          = new LongAdder
+      private val currentCount    = new LongAdder
+      private val sum0            = new DoubleAdder
+      private val sortedQuantiles = quantiles.sorted(dblOrdering)
 
       override def toString = s"ConcurrentSummary.manual(${count()}, ${sum()})"
 

--- a/core/shared/src/main/scala-3/zio/zmx/internal/WithDoubleOrdering.scala
+++ b/core/shared/src/main/scala-3/zio/zmx/internal/WithDoubleOrdering.scala
@@ -1,0 +1,5 @@
+package zio.zmx.internal
+
+private[zmx] object ScalaCompat {
+  val dblOrdering = Ordering.Double.TotalOrdering
+}

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -7,7 +7,7 @@ object BuildHelper {
   val Scala211   = "2.11.12"
   val Scala212   = "2.12.14"
   val Scala213   = "2.13.6"
-  val ScalaDotty = "3.0.1"
+  val ScalaDotty = "3.0.2"
 
   private val stdOptions = Seq(
     "-encoding",


### PR DESCRIPTION
Hello, I would like to use zio-zmx in scala 3 based project so I added support for this and also :
- zio-json version is changed to 0.2.0-M1, the one that is released for scala 3
- most likely there was a [problem](https://github.com/suzaku-io/boopickle/issues/170) with boopickle derivation for sealed traits, so here's a workaround for that, til there's a fix out there
- zio-nio dependency was removed
