### PR TITLE
Prometheus style JVM metrics

### DIFF
--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/BufferPools.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/BufferPools.scala
@@ -5,7 +5,7 @@ import zio.zmx.metrics.{ MetricAspect, MetricsSyntax }
 import zio.{ Task, ZIO, ZManaged }
 
 import java.lang.management.{ BufferPoolMXBean, ManagementFactory }
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object BufferPools extends JvmMetrics {
 

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/BufferPools.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/BufferPools.scala
@@ -1,0 +1,48 @@
+package zio.zmx.metrics.jvm
+
+import zio.clock.Clock
+import zio.zmx.metrics.{ MetricAspect, MetricsSyntax }
+import zio.{ Task, ZIO, ZManaged }
+
+import java.lang.management.{ BufferPoolMXBean, ManagementFactory }
+import scala.jdk.CollectionConverters._
+
+object BufferPools extends JvmMetrics {
+
+  /** Used bytes of a given JVM buffer pool. */
+  private def bufferPoolUsedBytes(pool: String): MetricAspect[Long]     =
+    MetricAspect.setGaugeWith("jvm_buffer_pool_used_bytes", "pool" -> pool)(_.toDouble)
+
+  /** Bytes capacity of a given JVM buffer pool. */
+  private def bufferPoolCapacityBytes(pool: String): MetricAspect[Long] =
+    MetricAspect.setGaugeWith("jvm_buffer_pool_capacity_bytes", "pool" -> pool)(_.toDouble)
+
+  /** Used buffers of a given JVM buffer pool. */
+  private def bufferPoolUsedBuffers(pool: String): MetricAspect[Long]   =
+    MetricAspect.setGaugeWith("jvm_buffer_pool_used_buffers", "pool" -> pool)(_.toDouble)
+
+  private def reportBufferPoolMetrics(
+    bufferPoolMXBeans: List[BufferPoolMXBean]
+  ): ZIO[Any, Throwable, Unit]                                          =
+    ZIO.foreach_(bufferPoolMXBeans) { bufferPoolMXBean =>
+      for {
+        name <- Task(bufferPoolMXBean.getName)
+        _    <- Task(bufferPoolMXBean.getMemoryUsed) @@ bufferPoolUsedBytes(name)
+        _    <- Task(bufferPoolMXBean.getTotalCapacity) @@ bufferPoolCapacityBytes(name)
+        _    <- Task(bufferPoolMXBean.getCount) @@ bufferPoolUsedBuffers(name)
+      } yield ()
+    }
+
+  val collectMetrics: ZManaged[Clock, Throwable, Unit] =
+    ZManaged.make {
+      for {
+        bufferPoolMXBeans <-
+          Task(ManagementFactory.getPlatformMXBeans(classOf[BufferPoolMXBean]).asScala.toList)
+        fiber             <-
+          reportBufferPoolMetrics(bufferPoolMXBeans)
+            .repeat(collectionSchedule)
+            .interruptible
+            .forkDaemon
+      } yield fiber
+    }(_.interrupt).unit
+}

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/ClassLoading.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/ClassLoading.scala
@@ -1,0 +1,44 @@
+package zio.zmx.metrics.jvm
+
+import zio.clock.Clock
+import zio.zmx.metrics._
+import zio.{ Task, ZIO, ZManaged }
+
+import java.lang.management.{ ClassLoadingMXBean, ManagementFactory }
+
+/** Exports metrics related to JVM class loading */
+object ClassLoading extends JvmMetrics {
+
+  /** The number of classes that are currently loaded in the JVM */
+  private val loadedClassCount: MetricAspect[Int] =
+    MetricAspect.setGaugeWith("jvm_classes_loaded")(_.toDouble)
+
+  /** The total number of classes that have been loaded since the JVM has started execution */
+  private val totalLoadedClassCount: MetricAspect[Long] =
+    MetricAspect.setGaugeWith("jvm_classes_loaded_total")(_.toDouble)
+
+  /** The total number of classes that have been unloaded since the JVM has started execution */
+  private val unloadedClassCount: MetricAspect[Long] =
+    MetricAspect.setGaugeWith("jvm_classes_unloaded_total")(_.toDouble)
+
+  private def reportClassLoadingMetrics(
+    classLoadingMXBean: ClassLoadingMXBean
+  ): ZIO[Any, Throwable, Unit] =
+    for {
+      _ <- Task(classLoadingMXBean.getLoadedClassCount) @@ loadedClassCount
+      _ <- Task(classLoadingMXBean.getTotalLoadedClassCount) @@ totalLoadedClassCount
+      _ <- Task(classLoadingMXBean.getUnloadedClassCount) @@ unloadedClassCount
+    } yield ()
+
+  val collectMetrics: ZManaged[Clock, Throwable, Unit] =
+    ZManaged.make {
+      for {
+        classLoadingMXBean <-
+          Task(ManagementFactory.getPlatformMXBean(classOf[ClassLoadingMXBean]))
+        fiber              <- reportClassLoadingMetrics(classLoadingMXBean)
+                                .repeat(collectionSchedule)
+                                .interruptible
+                                .forkDaemon
+      } yield fiber
+    }(_.interrupt).unit
+}

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/DefaultJvmMetrics.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/DefaultJvmMetrics.scala
@@ -1,0 +1,27 @@
+package zio.zmx.metrics.jvm
+
+import zio.{ Has, ZLayer, ZManaged }
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.system.System
+
+trait DefaultJvmMetrics
+
+/** JVM metrics, compatible with the prometheus-hotspot library */
+object DefaultJvmMetrics {
+  val collectDefaultJvmMetrics: ZManaged[Clock with System with Blocking, Throwable, Unit] =
+    (
+      BufferPools.collectMetrics <&>
+        ClassLoading.collectMetrics <&>
+        GarbageCollector.collectMetrics <&>
+        MemoryAllocation.collectMetrics <&>
+        MemoryPools.collectMetrics <&>
+        Standard.collectMetrics <&>
+        Thread.collectMetrics <&>
+        VersionInfo.collectMetrics
+    ).unit
+
+  /** Layer that starts collecting the same JVM metrics as the Prometheus Java client's default exporters */
+  val live: ZLayer[Clock with System with Blocking, Throwable, Has[DefaultJvmMetrics]] =
+    collectDefaultJvmMetrics.as(new DefaultJvmMetrics {}).toLayer
+}

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/GarbageCollector.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/GarbageCollector.scala
@@ -1,0 +1,42 @@
+package zio.zmx.metrics.jvm
+
+import zio.clock.Clock
+import zio.zmx.metrics._
+import zio.{ Task, ZIO, ZManaged }
+
+import java.lang.management.{ GarbageCollectorMXBean, ManagementFactory }
+import scala.jdk.CollectionConverters._
+
+/** Exports metrics related to the garbage collector */
+object GarbageCollector extends JvmMetrics {
+
+  /** Time spent in a given JVM garbage collector in seconds. */
+  private def gcCollectionSecondsSum(gc: String): MetricAspect[Long]   =
+    MetricAspect.setGaugeWith("jvm_gc_collection_seconds_sum", "gc" -> gc)((ms: Long) => ms.toDouble / 1000.0)
+
+  private def gcCollectionSecondsCount(gc: String): MetricAspect[Long] =
+    MetricAspect.setGaugeWith("jvm_gc_collection_seconds_count", "gc" -> gc)(_.toDouble)
+
+  private def reportGarbageCollectionMetrics(
+    garbageCollectors: List[GarbageCollectorMXBean]
+  ): ZIO[Any, Throwable, Unit]                                         =
+    ZIO.foreachPar_(garbageCollectors) { gc =>
+      for {
+        name <- Task(gc.getName)
+        _    <- Task(gc.getCollectionCount) @@ gcCollectionSecondsCount(name)
+        _    <- Task(gc.getCollectionTime) @@ gcCollectionSecondsSum(name)
+      } yield ()
+    }
+
+  val collectMetrics: ZManaged[Clock, Throwable, Unit] =
+    ZManaged.make {
+      for {
+        classLoadingMXBean <- Task(ManagementFactory.getGarbageCollectorMXBeans.asScala.toList)
+        fiber              <-
+          reportGarbageCollectionMetrics(classLoadingMXBean)
+            .repeat(collectionSchedule)
+            .interruptible
+            .forkDaemon
+      } yield fiber
+    }(_.interrupt).unit
+}

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/GarbageCollector.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/GarbageCollector.scala
@@ -5,7 +5,7 @@ import zio.zmx.metrics._
 import zio.{ Task, ZIO, ZManaged }
 
 import java.lang.management.{ GarbageCollectorMXBean, ManagementFactory }
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /** Exports metrics related to the garbage collector */
 object GarbageCollector extends JvmMetrics {

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/JvmMetrics.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/JvmMetrics.scala
@@ -1,0 +1,13 @@
+package zio.zmx.metrics.jvm
+
+import zio.{ Schedule, ZManaged }
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.duration._
+import zio.system.System
+
+trait JvmMetrics {
+  protected val collectionSchedule: Schedule[Any, Any, Unit] = Schedule.fixed(10.seconds).unit
+
+  val collectMetrics: ZManaged[Clock with System with Blocking, Throwable, Unit]
+}

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/MemoryAllocation.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/MemoryAllocation.scala
@@ -10,7 +10,7 @@ import java.lang.management.ManagementFactory
 import javax.management.openmbean.CompositeData
 import javax.management.{ Notification, NotificationEmitter, NotificationListener }
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object MemoryAllocation extends JvmMetrics {
 

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/MemoryAllocation.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/MemoryAllocation.scala
@@ -1,0 +1,94 @@
+package zio.zmx.metrics.jvm
+
+import com.sun.management.GarbageCollectionNotificationInfo
+import zio.clock.Clock
+import zio.system.System
+import zio.zmx.metrics.{ MetricAspect, MetricsSyntax }
+import zio.{ Runtime, Task, UIO, ZIO, ZManaged }
+
+import java.lang.management.ManagementFactory
+import javax.management.openmbean.CompositeData
+import javax.management.{ Notification, NotificationEmitter, NotificationListener }
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+object MemoryAllocation extends JvmMetrics {
+
+  /** Total bytes allocated in a given JVM memory pool. Only updated after GC, not continuously. */
+  private def countAllocations(pool: String): MetricAspect[Long] =
+    MetricAspect.countValueWith("jvm_memory_pool_allocated_bytes_total", "pool" -> pool)(_.toDouble)
+
+  private class Listener(runtime: Runtime[Any]) extends NotificationListener {
+    private val lastMemoryUsage: mutable.Map[String, Long] = mutable.HashMap.empty
+
+    override def handleNotification(notification: Notification, handback: Any): Unit = {
+      val info                =
+        GarbageCollectionNotificationInfo.from(notification.getUserData.asInstanceOf[CompositeData])
+      val gcInfo              = info.getGcInfo
+      val memoryUsageBeforeGc = gcInfo.getMemoryUsageBeforeGc
+      val memoryUsageAfterGc  = gcInfo.getMemoryUsageAfterGc
+      for (entry <- memoryUsageBeforeGc.entrySet.asScala) {
+        val memoryPool = entry.getKey
+        val before     = entry.getValue.getUsed
+        val after      = memoryUsageAfterGc.get(memoryPool).getUsed
+        handleMemoryPool(memoryPool, before, after)
+      }
+    }
+
+    private def handleMemoryPool(memoryPool: String, before: Long, after: Long): Unit = {
+      /*
+       * Calculate increase in the memory pool by comparing memory used
+       * after last GC, before this GC, and after this GC.
+       * See ascii illustration below.
+       * Make sure to count only increases and ignore decreases.
+       * (Typically a pool will only increase between GCs or during GCs, not both.
+       * E.g. eden pools between GCs. Survivor and old generation pools during GCs.)
+       *
+       *                         |<-- diff1 -->|<-- diff2 -->|
+       * Timeline: |-- last GC --|             |---- GC -----|
+       *                      ___^__        ___^____      ___^___
+       * Mem. usage vars:    / last \      / before \    / after \
+       */
+      // Get last memory usage after GC and remember memory used after for next time
+      val last     = lastMemoryUsage.getOrElse(memoryPool, 0L)
+      lastMemoryUsage.put(memoryPool, after)
+      // Difference since last GC
+      var diff1    = before - last
+      // Difference during this GC
+      var diff2    = after - before
+      // Make sure to only count increases
+      if (diff1 < 0) diff1 = 0
+      if (diff2 < 0) diff2 = 0
+      val increase = diff1 + diff2
+      if (increase > 0) {
+        runtime.unsafeRun {
+          (UIO(increase) @@ countAllocations(memoryPool)).unit
+        }
+      }
+    }
+  }
+
+  override val collectMetrics: ZManaged[Clock with System, Throwable, Unit] =
+    ZManaged
+      .make(
+        for {
+          runtime                 <- ZIO.runtime[Any]
+          listener                 = new Listener(runtime)
+          garbageCollectorMXBeans <- Task(ManagementFactory.getGarbageCollectorMXBeans.asScala)
+          _                       <- ZIO.foreach_(garbageCollectorMXBeans) {
+                                       case emitter: NotificationEmitter =>
+                                         Task(emitter.addNotificationListener(listener, null, null))
+                                       case _                            => ZIO.unit
+                                     }
+        } yield (listener, garbageCollectorMXBeans)
+      ) { case (listener, garbageCollectorMXBeans) =>
+        ZIO
+          .foreach_(garbageCollectorMXBeans) {
+            case emitter: NotificationEmitter =>
+              Task(emitter.removeNotificationListener(listener))
+            case _                            => ZIO.unit
+          }
+          .orDie
+      }
+      .unit
+}

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/MemoryPools.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/MemoryPools.scala
@@ -1,0 +1,94 @@
+package zio.zmx.metrics.jvm
+
+import zio.clock.Clock
+import zio.zmx.metrics.{ MetricAspect, MetricsSyntax }
+import zio.{ Task, UIO, ZIO, ZManaged }
+
+import java.lang.management.{ ManagementFactory, MemoryMXBean, MemoryPoolMXBean, MemoryUsage }
+import scala.jdk.CollectionConverters._
+
+object MemoryPools extends JvmMetrics {
+
+  sealed private trait Area { val label: String }
+  private case object Heap    extends Area { override val label: String = "heap"    }
+  private case object NonHeap extends Area { override val label: String = "nonheap" }
+
+  /** Used bytes of a given JVM memory area. */
+  private def memoryBytesUsed(area: Area): MetricAspect[Long]                            =
+    MetricAspect.setGaugeWith("jvm_memory_bytes_used", "area" -> area.label)(_.toDouble)
+
+  /** Committed (bytes) of a given JVM memory area. */
+  private def memoryBytesCommitted(area: Area): MetricAspect[Long]                       =
+    MetricAspect.setGaugeWith("jvm_memory_bytes_committed", "area" -> area.label)(_.toDouble)
+
+  /** Max (bytes) of a given JVM memory area. */
+  private def memoryBytesMax(area: Area): MetricAspect[Long]                             =
+    MetricAspect.setGaugeWith("jvm_memory_bytes_max", "area" -> area.label)(_.toDouble)
+
+  /** Initial bytes of a given JVM memory area. */
+  private def memoryBytesInit(area: Area): MetricAspect[Long]                            =
+    MetricAspect.setGaugeWith("jvm_memory_bytes_init", "area" -> area.label)(_.toDouble)
+
+  /** Used bytes of a given JVM memory pool. */
+  private def poolBytesUsed(pool: String): MetricAspect[Long]                            =
+    MetricAspect.setGaugeWith("jvm_memory_pool_bytes_used", "pool" -> pool)(_.toDouble)
+
+  /** Committed bytes of a given JVM memory pool. */
+  private def poolBytesCommitted(pool: String): MetricAspect[Long]                       =
+    MetricAspect.setGaugeWith("jvm_memory_pool_bytes_committed", "pool" -> pool)(_.toDouble)
+
+  /** Max bytes of a given JVM memory pool. */
+  private def poolBytesMax(pool: String): MetricAspect[Long]                             =
+    MetricAspect.setGaugeWith("jvm_memory_pool_bytes_max", "pool" -> pool)(_.toDouble)
+
+  /** Initial bytes of a given JVM memory pool. */
+  private def poolBytesInit(pool: String): MetricAspect[Long]                            =
+    MetricAspect.setGaugeWith("jvm_memory_pool_bytes_init", "pool" -> pool)(_.toDouble)
+
+  private def reportMemoryUsage(usage: MemoryUsage, area: Area): ZIO[Any, Nothing, Unit] =
+    for {
+      _ <- UIO(usage.getUsed) @@ memoryBytesUsed(area)
+      _ <- UIO(usage.getCommitted) @@ memoryBytesCommitted(area)
+      _ <- UIO(usage.getMax) @@ memoryBytesMax(area)
+      _ <- UIO(usage.getInit) @@ memoryBytesInit(area)
+    } yield ()
+
+  private def reportPoolUsage(usage: MemoryUsage, pool: String): ZIO[Any, Nothing, Unit] =
+    for {
+      _ <- UIO(usage.getUsed) @@ poolBytesUsed(pool)
+      _ <- UIO(usage.getCommitted) @@ poolBytesCommitted(pool)
+      _ <- UIO(usage.getMax) @@ poolBytesMax(pool)
+      _ <- UIO(usage.getInit) @@ poolBytesInit(pool)
+    } yield ()
+
+  private def reportMemoryMetrics(
+    memoryMXBean: MemoryMXBean,
+    poolMXBeans: List[MemoryPoolMXBean]
+  ): ZIO[Any, Throwable, Unit] =
+    for {
+      heapUsage    <- Task(memoryMXBean.getHeapMemoryUsage)
+      nonHeapUsage <- Task(memoryMXBean.getNonHeapMemoryUsage)
+      _            <- reportMemoryUsage(heapUsage, Heap)
+      _            <- reportMemoryUsage(nonHeapUsage, NonHeap)
+      _            <- ZIO.foreachPar_(poolMXBeans) { pool =>
+                        for {
+                          name  <- Task(pool.getName)
+                          usage <- Task(pool.getUsage)
+                          _     <- reportPoolUsage(usage, name)
+                        } yield ()
+                      }
+    } yield ()
+
+  val collectMetrics: ZManaged[Clock, Throwable, Unit] =
+    ZManaged.make {
+      for {
+        memoryMXBean <- Task(ManagementFactory.getMemoryMXBean)
+        poolMXBeans  <- Task(ManagementFactory.getMemoryPoolMXBeans.asScala.toList)
+        fiber        <-
+          reportMemoryMetrics(memoryMXBean, poolMXBeans)
+            .repeat(collectionSchedule)
+            .interruptible
+            .forkDaemon
+      } yield fiber
+    }(_.interrupt).unit
+}

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/MemoryPools.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/MemoryPools.scala
@@ -5,7 +5,7 @@ import zio.zmx.metrics.{ MetricAspect, MetricsSyntax }
 import zio.{ Task, UIO, ZIO, ZManaged }
 
 import java.lang.management.{ ManagementFactory, MemoryMXBean, MemoryPoolMXBean, MemoryUsage }
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object MemoryPools extends JvmMetrics {
 

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/Standard.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/Standard.scala
@@ -1,0 +1,139 @@
+package zio.zmx.metrics.jvm
+
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.system.System
+import zio.zmx.metrics._
+import zio.{ Chunk, Task, ZIO, ZManaged }
+
+import java.lang.management.{ ManagementFactory, PlatformManagedObject, RuntimeMXBean }
+import java.lang.reflect.Method
+import java.nio.charset.StandardCharsets
+import scala.util.{ Failure, Success, Try }
+
+object Standard extends JvmMetrics {
+
+  /** Total user and system CPU time spent in seconds. */
+  private val cpuSecondsTotal: MetricAspect[Long] =
+    MetricAspect.setGaugeWith("process_cpu_seconds_total")(_.toDouble / 1.0e09)
+
+  /** Start time of the process since unix epoch in seconds. */
+  private val processStartTime: MetricAspect[Long] =
+    MetricAspect.setGaugeWith("process_start_time_seconds")(_.toDouble / 1000.0)
+
+  /** Number of open file descriptors. */
+  private val openFdCount: MetricAspect[Long] =
+    MetricAspect.setGaugeWith("process_open_fds")(_.toDouble)
+
+  /** Maximum number of open file descriptors. */
+  private val maxFdCount: MetricAspect[Long] =
+    MetricAspect.setGaugeWith("process_max_fds")(_.toDouble)
+
+  /** Virtual memory size in bytes. */
+  private val virtualMemorySize: MetricAspect[Double] =
+    MetricAspect.setGauge("process_virtual_memory_bytes")
+
+  /** Resident memory size in bytes. */
+  private val residentMemorySize: MetricAspect[Double] =
+    MetricAspect.setGauge("process_resident_memory_bytes")
+
+  class MXReflection(getterName: String, obj: PlatformManagedObject) {
+    private val cls: Class[_ <: PlatformManagedObject] = obj.getClass
+    private val method: Option[Method]                 = findGetter(Try(cls.getMethod(getterName)))
+
+    def isAvailable: Boolean = method.isDefined
+
+    def unsafeGet: Task[Long] =
+      method match {
+        case Some(getter) => Task(getter.invoke(obj).asInstanceOf[Long])
+        case None         =>
+          ZIO.fail(new IllegalStateException(s"MXReflection#get called on unavailable metri"))
+      }
+
+    private def findGetter(getter: Try[Method]): Option[Method] =
+      getter match {
+        case Failure(_)      =>
+          None
+        case Success(method) =>
+          try {
+            val _ = method.invoke(obj).asInstanceOf[Long]
+            Some(method)
+          } catch {
+            case _: IllegalAccessException =>
+              method.getDeclaringClass.getInterfaces
+                .to(LazyList)
+                .flatMap { iface =>
+                  findGetter(Try(iface.getMethod(getterName)))
+                }
+                .headOption
+          }
+      }
+  }
+
+  private def reportStandardMetrics(
+    runtimeMXBean: RuntimeMXBean,
+    getProcessCPUTime: MXReflection,
+    getOpenFileDescriptorCount: MXReflection,
+    getMaxFileDescriptorCount: MXReflection,
+    isLinux: Boolean
+  ): ZIO[Blocking, Throwable, Unit] =
+    for {
+      _ <- (getProcessCPUTime.unsafeGet @@ cpuSecondsTotal).when(getProcessCPUTime.isAvailable)
+      _ <- Task(runtimeMXBean.getStartTime) @@ processStartTime
+      _ <- (getOpenFileDescriptorCount.unsafeGet @@ openFdCount).when(
+             getOpenFileDescriptorCount.isAvailable
+           )
+      _ <- (getMaxFileDescriptorCount.unsafeGet @@ maxFdCount).when(
+             getMaxFileDescriptorCount.isAvailable
+           )
+      _ <- collectMemoryMetricsLinux().when(isLinux)
+    } yield ()
+
+  private def collectMemoryMetricsLinux(): ZIO[Blocking, Throwable, Unit] =
+    ZManaged.readFile("/proc/self/status").use { stream =>
+      stream
+        .readAll(8192)
+        .catchAll {
+          case None        => ZIO.succeed(Chunk.empty)
+          case Some(error) => ZIO.fail(error)
+        }
+        .flatMap { bytes =>
+          Task(new String(bytes.toArray, StandardCharsets.US_ASCII)).flatMap { raw =>
+            ZIO.foreach_(raw.split('\n')) { line =>
+              if (line.startsWith("VmSize:")) {
+                Task(line.split("\\s+")(1).toDouble * 1024.0) @@ virtualMemorySize
+              } else if (line.startsWith("VmRSS:")) {
+                Task(line.split("\\s+")(1).toDouble * 1024.0) @@ residentMemorySize
+              } else {
+                ZIO.unit
+              }
+            }
+          }
+        }
+    }
+
+  override val collectMetrics: ZManaged[Clock with System with Blocking, Throwable, Unit] =
+    ZManaged.make {
+      for {
+        runtimeMXBean             <- Task(ManagementFactory.getRuntimeMXBean)
+        operatingSystemMXBean     <- Task(ManagementFactory.getOperatingSystemMXBean)
+        getProcessCpuTime          = new MXReflection("getProcessCpuTime", operatingSystemMXBean)
+        getOpenFileDescriptorCount =
+          new MXReflection("getOpenFileDescriptorCount", operatingSystemMXBean)
+        getMaxFileDescriptorCount  =
+          new MXReflection("getMaxFileDescriptorCount", operatingSystemMXBean)
+        isLinux                   <- Task(operatingSystemMXBean.getName.indexOf("Linux") == 0)
+        fiber                     <-
+          reportStandardMetrics(
+            runtimeMXBean,
+            getProcessCpuTime,
+            getOpenFileDescriptorCount,
+            getMaxFileDescriptorCount,
+            isLinux
+          )
+            .repeat(collectionSchedule)
+            .interruptible
+            .forkDaemon
+      } yield fiber
+    }(_.interrupt).unit
+}

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/Standard.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/Standard.scala
@@ -60,12 +60,9 @@ object Standard extends JvmMetrics {
             Some(method)
           } catch {
             case _: IllegalAccessException =>
-              method.getDeclaringClass.getInterfaces
-                .to(LazyList)
-                .flatMap { iface =>
-                  findGetter(Try(iface.getMethod(getterName)))
-                }
-                .headOption
+              method.getDeclaringClass.getInterfaces.toStream.flatMap { iface =>
+                findGetter(Try(iface.getMethod(getterName)))
+              }.headOption
           }
       }
   }

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/Thread.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/Thread.scala
@@ -1,0 +1,79 @@
+package zio.zmx.metrics.jvm
+import zio.clock.Clock
+import zio.zmx.metrics.{ MetricAspect, MetricsSyntax }
+import zio.{ system, Task, UIO, ZIO, ZManaged }
+
+import java.lang.management.{ ManagementFactory, ThreadMXBean }
+
+object Thread extends JvmMetrics {
+
+  /** Current thread count of a JVM */
+  private val threadsCurrent: MetricAspect[Int] =
+    MetricAspect.setGaugeWith("jvm_threads_current")(_.toDouble)
+
+  /** Daemon thread count of a JVM */
+  private val threadsDaemon: MetricAspect[Int] =
+    MetricAspect.setGaugeWith("jvm_threads_daemon")(_.toDouble)
+
+  /** Peak thread count of a JVM */
+  private val threadsPeak: MetricAspect[Int] =
+    MetricAspect.setGaugeWith("jvm_threads_peak")(_.toDouble)
+
+  /** Started thread count of a JVM */
+  private val threadsStartedTotal: MetricAspect[Long] =
+    MetricAspect.setGaugeWith("jvm_threads_started_total")(
+      _.toDouble
+    ) // NOTE: this is a counter in the prometheus hotspot library (but explicitly set to an actual value)
+
+  /** Cycles of JVM-threads that are in deadlock waiting to acquire object monitors or ownable synchronizers */
+  private val threadsDeadlocked: MetricAspect[Int] =
+    MetricAspect.setGaugeWith("jvm_threads_deadlocked")(_.toDouble)
+
+  /** Cycles of JVM-threads that are in deadlock waiting to acquire object monitors */
+  private val threadsDeadlockedMonitor: MetricAspect[Int] =
+    MetricAspect.setGaugeWith("jvm_threads_deadlocked_monitor")(_.toDouble)
+
+  /** Current count of threads by state */
+  private def threadsState(state: java.lang.Thread.State): MetricAspect[Long] =
+    MetricAspect.setGaugeWith("jvm_threads_state", "state" -> state.name())(_.toDouble)
+
+  private def getThreadStateCounts(
+    threadMXBean: ThreadMXBean
+  ): Task[Map[java.lang.Thread.State, Long]]                                  =
+    for {
+      allThreads <- Task(threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds, 0))
+      initial     = java.lang.Thread.State.values().map(_ -> 0L).toMap
+      result      = allThreads.foldLeft(initial) { (result, thread) =>
+                      if (thread != null) {
+                        result.updated(thread.getThreadState, result(thread.getThreadState) + 1)
+                      } else result
+                    }
+    } yield result
+
+  private def reportThreadMetrics(threadMXBean: ThreadMXBean): ZIO[Any, Throwable, Unit] =
+    for {
+      _                 <- Task(threadMXBean.getThreadCount) @@ threadsCurrent
+      _                 <- Task(threadMXBean.getDaemonThreadCount) @@ threadsDaemon
+      _                 <- Task(threadMXBean.getPeakThreadCount) @@ threadsPeak
+      _                 <- Task(threadMXBean.getTotalStartedThreadCount) @@ threadsStartedTotal
+      _                 <- Task(
+                             Option(threadMXBean.findDeadlockedThreads()).map(_.length).getOrElse(0)
+                           ) @@ threadsDeadlocked
+      _                 <- Task(
+                             Option(threadMXBean.findMonitorDeadlockedThreads()).map(_.length).getOrElse(0)
+                           ) @@ threadsDeadlockedMonitor
+      threadStateCounts <- getThreadStateCounts(threadMXBean)
+      _                 <- ZIO.foreach_(threadStateCounts) { case (state, count) =>
+                             UIO(count) @@ threadsState(state)
+                           }
+    } yield ()
+
+  override val collectMetrics: ZManaged[Clock with system.System, Throwable, Unit] =
+    ZManaged.make {
+      for {
+        threadMXBean <- Task(ManagementFactory.getThreadMXBean)
+        fiber        <-
+          reportThreadMetrics(threadMXBean).repeat(collectionSchedule).interruptible.forkDaemon
+      } yield fiber
+    }(_.interrupt).unit
+}

--- a/core/jvm/src/main/scala/zio/zmx/metrics/jvm/VersionInfo.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/jvm/VersionInfo.scala
@@ -1,0 +1,32 @@
+package zio.zmx.metrics.jvm
+import zio.clock.Clock
+import zio.system._
+import zio.zmx.metrics.{ MetricAspect, MetricsSyntax }
+import zio.{ system, ZIO, ZManaged }
+
+object VersionInfo extends JvmMetrics {
+
+  /** JVM version info */
+  def jvmInfo(version: String, vendor: String, runtime: String): MetricAspect[Unit] =
+    MetricAspect.setGaugeWith(
+      "jvm_info",
+      "version" -> version,
+      "vendor"  -> vendor,
+      "runtime" -> runtime
+    )(_ => 1.0)
+
+  private def reportVersions(): ZIO[System, Throwable, Unit] =
+    for {
+      version <- system.propertyOrElse("java.runtime.version", "unknown")
+      vendor  <- system.propertyOrElse("java.vm.vendor", "unknown")
+      runtime <- system.propertyOrElse("java.runtime.name", "unknown")
+      _       <- ZIO.unit @@ jvmInfo(version, vendor, runtime)
+    } yield ()
+
+  override val collectMetrics: ZManaged[Clock with System, Throwable, Unit] =
+    ZManaged.make {
+      for {
+        fiber <- reportVersions().repeat(collectionSchedule).interruptible.forkDaemon
+      } yield fiber
+    }(_.interrupt).unit
+}


### PR DESCRIPTION
This is a direct port of the JVM metrics provided by the Prometheus Java HotSpot library (https://github.com/prometheus/client_java/blob/master/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java)

The goal is to export the same set of of metrics supporting seamless migration from the Java Prometheus client to zio-zmx.