### PR TITLE
Thread-safe ConcurrentSummary

### DIFF
--- a/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSummary.scala
+++ b/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSummary.scala
@@ -4,7 +4,7 @@ import zio.duration.Duration
 import zio.zmx.internal.ScalaCompat._
 import zio.{ Chunk, ChunkBuilder }
 
-import java.util.concurrent.atomic.{ AtomicInteger, AtomicLong, DoubleAdder, LongAdder }
+import java.util.concurrent.atomic.{ AtomicInteger, AtomicReferenceArray, DoubleAdder, LongAdder }
 import scala.annotation.tailrec
 
 sealed abstract class ConcurrentSummary {
@@ -30,9 +30,8 @@ object ConcurrentSummary {
 
   def manual(maxSize: Int, maxAge: Duration, error: Double, quantiles: Chunk[Double]): ConcurrentSummary =
     new ConcurrentSummary {
-      private val values                 = new Array[(java.time.Instant, Double)](maxSize)
-      private val head                   = new AtomicInteger(0)
-      @volatile private var updated: Int = 0
+      private val values = new AtomicReferenceArray[(java.time.Instant, Double)](maxSize)
+      private val head   = new AtomicInteger(0)
 
       private val count0          = new LongAdder
       private val sum0            = new DoubleAdder
@@ -57,9 +56,8 @@ object ConcurrentSummary {
         // them by timestamp to get a valid view of a time window.
         // The order does not matter because it gets sorted before passing to calculateQuantiles.
 
-        val _ = updated
         for (idx <- 0 until maxSize) {
-          val item = values(idx)
+          val item = values.get(idx)
           if (item != null) {
             val (t, v) = item
             val age    = Duration.fromInterval(t, now)
@@ -77,11 +75,10 @@ object ConcurrentSummary {
       def observe(value: Double, t: java.time.Instant): Unit = {
         if (maxSize > 0) {
           val target = head.incrementAndGet() % maxSize
-          values(target) = (t, value)
+          values.set(target, (t, value))
         }
         count0.increment()
         sum0.add(value)
-        updated = updated + 1
       }
 
       private def calculateQuantiles(

--- a/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSummary.scala
+++ b/core/jvm/src/main/scala/zio/zmx/internal/ConcurrentSummary.scala
@@ -75,7 +75,7 @@ object ConcurrentSummary {
       def observe(value: Double, t: java.time.Instant): Unit = {
         if (maxSize > 0) {
           val target = head.incrementAndGet() % maxSize
-          values.set(target) = (t, value)
+          values.set(target, (t, value))
         }
         count0.increment()
         sum0.add(value)

--- a/core/jvm/src/test/scala/zio/zmx/internal/ConcurrentSummarySpec.scala
+++ b/core/jvm/src/test/scala/zio/zmx/internal/ConcurrentSummarySpec.scala
@@ -56,10 +56,10 @@ object ConcurrentSummarySpec extends DefaultRunnableSpec {
                 f2       <- observe.repeat(Schedule.upTo(2.seconds) *> Schedule.count).forkDaemon
                 _        <- getSnapshot.repeat(Schedule.upTo(2.seconds))
                 snapshot <- getSnapshot
-                count    <- ZIO.effect(summary.count())
-                sum      <- ZIO.effect(summary.sum())
                 f1Count  <- f1.join
                 f2Count  <- f2.join
+                count    <- ZIO.effect(summary.count())
+                sum      <- ZIO.effect(summary.sum())
               } yield assertTrue(
                 snapshot.length <= maxSize,
                 count == (f1Count + f2Count + 2),

--- a/core/jvm/src/test/scala/zio/zmx/internal/ConcurrentSummarySpec.scala
+++ b/core/jvm/src/test/scala/zio/zmx/internal/ConcurrentSummarySpec.scala
@@ -1,0 +1,130 @@
+package zio.zmx.internal
+
+import zio.clock.Clock
+import zio.duration._
+import zio.test._
+import zio.test.environment.{ TestClock, TestEnvironment }
+import zio.{ clock, Chunk, Schedule, ZIO }
+
+object ConcurrentSummarySpec extends DefaultRunnableSpec {
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("ConcurrentSummary")(
+      testM("single observe works with maxSize = 0") {
+        val summary = ConcurrentSummary.manual(maxSize = 0, maxAge = 10.seconds, error = 0.0, quantiles = Chunk.empty)
+        val observe = clock.instant.flatMap(now => ZIO.effect(summary.observe(11.0, now)))
+
+        for {
+          _        <- observe
+          now      <- clock.instant
+          snapshot <- ZIO.effect(summary.snapshot(now))
+          count    <- ZIO.effect(summary.count())
+          sum      <- ZIO.effect(summary.sum())
+        } yield assertTrue(
+          snapshot.isEmpty,
+          count == 1,
+          sum == 11.0
+        )
+      },
+      testM("single observe works with arbitrary maxSize") {
+        checkM(Gen.int(0, 100000)) { maxSize =>
+          val summary = ConcurrentSummary.manual(maxSize, maxAge = 10.seconds, error = 0.0, quantiles = Chunk.empty)
+          val observe = clock.instant.flatMap(now => ZIO.effect(summary.observe(11.0, now)))
+
+          for {
+            _        <- observe
+            now      <- clock.instant
+            snapshot <- ZIO.effect(summary.snapshot(now))
+            count    <- ZIO.effect(summary.count())
+            sum      <- ZIO.effect(summary.sum())
+          } yield assertTrue(
+            snapshot.length <= 1,
+            count == 1,
+            sum == 11.0
+          )
+        }
+      },
+      zio.test.suite("stable under load")(
+        Seq(0, 1, 100, 100000).map { maxSize =>
+          testM(s"maxSize = $maxSize") {
+            val summary     = ConcurrentSummary.manual(maxSize, maxAge = 10.seconds, error = 0.0, quantiles = Chunk.empty)
+            val observe     = clock.instant.flatMap(now => ZIO.effect(summary.observe(11.0, now)))
+            val getSnapshot = clock.instant.flatMap(now => ZIO.effect(summary.snapshot(now)))
+
+            val test =
+              for {
+                f1       <- observe.repeat(Schedule.upTo(2.seconds) *> Schedule.count).forkDaemon
+                f2       <- observe.repeat(Schedule.upTo(2.seconds) *> Schedule.count).forkDaemon
+                _        <- getSnapshot.repeat(Schedule.upTo(2.seconds))
+                snapshot <- getSnapshot
+                count    <- ZIO.effect(summary.count())
+                sum      <- ZIO.effect(summary.sum())
+                f1Count  <- f1.join
+                f2Count  <- f2.join
+              } yield assertTrue(
+                snapshot.length <= maxSize,
+                count == (f1Count + f2Count + 2),
+                sum == (f1Count + f2Count + 2) * 11.0
+              )
+
+            test.provideLayer(Clock.live)
+          }
+        }: _*
+      ),
+      testM(s"old measurements not used for quantiles with non-full buffer") {
+        val summary            =
+          ConcurrentSummary.manual(maxSize = 10, maxAge = 1.seconds, error = 0.0, quantiles = Chunk(0.5, 1.0))
+        def observe(v: Double) = clock.instant.flatMap(now => ZIO.effect(summary.observe(v, now)))
+        val getSnapshot        = clock.instant.flatMap(now => ZIO.effect(summary.snapshot(now)))
+
+        for {
+          _        <- observe(1.0) // old
+          _        <- TestClock.adjust(300.millis)
+          _        <- observe(2.0) // old
+          _        <- TestClock.adjust(300.millis)
+          _        <- observe(3.0)
+          _        <- TestClock.adjust(300.millis)
+          _        <- observe(4.0)
+          _        <- TestClock.adjust(300.millis)
+          _        <- observe(5.0)
+          _        <- TestClock.adjust(300.millis)
+          snapshot <- getSnapshot
+          count    <- ZIO.effect(summary.count())
+          sum      <- ZIO.effect(summary.sum())
+        } yield assertTrue(
+          snapshot.length == 2,
+          snapshot(0) == (0.5, Some(3.0)),
+          snapshot(1) == (1.0, Some(5.0)),
+          count == 5,
+          sum == 1.0 + 2.0 + 3.0 + 4.0 + 5.0
+        )
+      },
+      testM(s"old measurements not used for quantiles with full buffer") {
+        val summary            =
+          ConcurrentSummary.manual(maxSize = 3, maxAge = 1.seconds, error = 0.0, quantiles = Chunk(0.5, 1.0))
+        def observe(v: Double) = clock.instant.flatMap(now => ZIO.effect(summary.observe(v, now)))
+        val getSnapshot        = clock.instant.flatMap(now => ZIO.effect(summary.snapshot(now)))
+
+        for {
+          _        <- observe(1.0) // old
+          _        <- TestClock.adjust(300.millis)
+          _        <- observe(2.0) // old
+          _        <- TestClock.adjust(300.millis)
+          _        <- observe(3.0)
+          _        <- TestClock.adjust(300.millis)
+          _        <- observe(4.0)
+          _        <- TestClock.adjust(300.millis)
+          _        <- observe(5.0)
+          _        <- TestClock.adjust(300.millis)
+          snapshot <- getSnapshot
+          count    <- ZIO.effect(summary.count())
+          sum      <- ZIO.effect(summary.sum())
+        } yield assertTrue(
+          snapshot.length == 2,
+          snapshot(0) == (0.5, Some(3.0)),
+          snapshot(1) == (1.0, Some(5.0)),
+          count == 5,
+          sum == 1.0 + 2.0 + 3.0 + 4.0 + 5.0
+        )
+      }
+    )
+}

--- a/core/jvm/src/test/scala/zio/zmx/internal/ConcurrentSummarySpec.scala
+++ b/core/jvm/src/test/scala/zio/zmx/internal/ConcurrentSummarySpec.scala
@@ -21,7 +21,7 @@ object ConcurrentSummarySpec extends DefaultRunnableSpec {
           sum      <- ZIO.effect(summary.sum())
         } yield assertTrue(
           snapshot.isEmpty,
-          count == 1,
+          count == 1L,
           sum == 11.0
         )
       },
@@ -38,7 +38,7 @@ object ConcurrentSummarySpec extends DefaultRunnableSpec {
             sum      <- ZIO.effect(summary.sum())
           } yield assertTrue(
             snapshot.length <= 1,
-            count == 1,
+            count == 1L,
             sum == 11.0
           )
         }
@@ -90,11 +90,13 @@ object ConcurrentSummarySpec extends DefaultRunnableSpec {
           snapshot <- getSnapshot
           count    <- ZIO.effect(summary.count())
           sum      <- ZIO.effect(summary.sum())
+          s0        = (0.5, Some(3.0))
+          s1        = (1.0, Some(5.0))
         } yield assertTrue(
           snapshot.length == 2,
-          snapshot(0) == (0.5, Some(3.0)),
-          snapshot(1) == (1.0, Some(5.0)),
-          count == 5,
+          snapshot(0) == s0,
+          snapshot(1) == s1,
+          count == 5L,
           sum == 1.0 + 2.0 + 3.0 + 4.0 + 5.0
         )
       },
@@ -118,11 +120,13 @@ object ConcurrentSummarySpec extends DefaultRunnableSpec {
           snapshot <- getSnapshot
           count    <- ZIO.effect(summary.count())
           sum      <- ZIO.effect(summary.sum())
+          s0        = (0.5, Some(3.0))
+          s1        = (1.0, Some(5.0))
         } yield assertTrue(
           snapshot.length == 2,
-          snapshot(0) == (0.5, Some(3.0)),
-          snapshot(1) == (1.0, Some(5.0)),
-          count == 5,
+          snapshot(0) == s0,
+          snapshot(1) == s1,
+          count == 5L,
           sum == 1.0 + 2.0 + 3.0 + 4.0 + 5.0
         )
       }


### PR DESCRIPTION
Attempt to fix https://github.com/zio/zio-zmx/issues/285

If the array gets updated during `snapshot` the snapshot will still be valid (just outdated) as each element's age (and existence) is verified.

Also fixes https://github.com/zio/zio-zmx/issues/284