### PR TITLE
Change the ZMXSupervisor's value creation from eager to lazy

### DIFF
--- a/core/jvm/src/main/scala/zio/zmx/diagnostics/package.scala
+++ b/core/jvm/src/main/scala/zio/zmx/diagnostics/package.scala
@@ -15,7 +15,7 @@ package object diagnostics {
         Platform.newConcurrentSet[Fiber.Runtime[Any, Any]]()
 
       val value: UIO[Set[Fiber.Runtime[Any, Any]]] =
-        UIO.succeedNow(fibers.asScala.toSet)
+        UIO.succeed(fibers.asScala.toSet)
 
       def unsafeOnStart[R, E, A](
         environment: R,


### PR DESCRIPTION
Fixes how the value of the Supervisor is exposed. With the current implementation the ZMXSupervisor always returns an empty set.